### PR TITLE
Add pbxNativeTarget method for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ To rebuild the parser js file after editing the grammar, run:
 
 ## License
 
-MIT
+Apache V2

--- a/lib/parseJob.js
+++ b/lib/parseJob.js
@@ -6,11 +6,10 @@ var fs = require('fs'),
     fileContents, obj;
 
 try {
-    fileContents = fs.readFileSync(path, 'utf-8'),
-    obj = parser.parse(fileContents)
-    process.send(obj)
-    process.exit()
+    fileContents = fs.readFileSync(path, 'utf-8');
+    obj = parser.parse(fileContents);
+    process.send(obj);
 } catch (e) {
-    process.send(e)
-    process.exit(1)
+    process.send(e);
+    process.exitCode = 1;
 }

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -94,8 +94,13 @@ function defaultEncoding(fileRef) {
 }
 
 function detectGroup(fileRef) {
-    var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
+    var extension = path.extname(this.basename).substring(1),
+        filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
+
+    if (extension === 'xcdatamodeld') {
+        return 'Sources';
+    }
 
     if (!groupName) {
         return DEFAULT_GROUP;

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -34,6 +34,7 @@ var FILETYPE_BY_EXTENSION = {
         'archive.ar': 'Frameworks',
         'compiled.mach-o.dylib': 'Frameworks',
         'wrapper.framework': 'Frameworks',
+        'embedded.framework': 'Embed Frameworks',
         'sourcecode.c.h': 'Resources',
         'sourcecode.c.objc': 'Sources',
         'sourcecode.swift': 'Sources'
@@ -93,13 +94,17 @@ function defaultEncoding(fileRef) {
     }
 }
 
-function detectGroup(fileRef) {
+function detectGroup(fileRef, opt) {
     var extension = path.extname(fileRef.basename).substring(1),
         filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
 
     if (extension === 'xcdatamodeld') {
         return 'Sources';
+    }
+
+    if (opt.customFramework && opt.embed) {
+        return GROUP_BY_FILETYPE['embedded.framework'];
     }
 
     if (!groupName) {
@@ -161,7 +166,7 @@ function pbxFile(filepath, opt) {
 
     this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
-    this.group = detectGroup(self);
+    this.group = detectGroup(self, opt);
 
     // for custom frameworks
     if (opt.customFramework == true) {
@@ -195,7 +200,7 @@ function pbxFile(filepath, opt) {
         this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
     }
 
-    if (opt.sign) {
+    if (opt.embed && opt.sign) {
       if (!this.settings)
           this.settings = {};
       if (!this.settings.ATTRIBUTES)

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -164,12 +164,11 @@ function defaultGroup(fileRef) {
 }
 
 function pbxFile(filepath, opt) {
-    var opt = opt || {},
-        self = this;
+    var opt = opt || {};
 
     this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
-    this.group = detectGroup(self, opt);
+    this.group = detectGroup(this, opt);
 
     // for custom frameworks
     if (opt.customFramework == true) {
@@ -178,7 +177,7 @@ function pbxFile(filepath, opt) {
     }
 
     this.path = defaultPath(this, filepath).replace(/\\/g, '/');
-    this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(self);
+    this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(this);
 
     // When referencing products / build output files
     if (opt.explicitFileType) {
@@ -190,7 +189,7 @@ function pbxFile(filepath, opt) {
         delete this.defaultEncoding;
     }
 
-    this.sourceTree = opt.sourceTree || detectSourcetree(self);
+    this.sourceTree = opt.sourceTree || detectSourcetree(this);
     this.includeInIndex = 0;
 
     if (opt.weak && opt.weak === true)

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -166,12 +166,11 @@ function pbxFile(filepath, opt) {
     // for custom frameworks
     if (opt.customFramework == true) {
         this.customFramework = true;
-        this.dirname = path.dirname(filepath);
+        this.dirname = path.dirname(filepath).replace(/\\/g, '/');
     }
 
-    this.path = defaultPath(this, filepath);
+    this.path = defaultPath(this, filepath).replace(/\\/g, '/');
     this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(self);
-
 
     // When referencing products / build output files
     if (opt.explicitFileType) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -91,43 +91,59 @@ function defaultExtension(fileRef) {
     return extension;
 }
 
+function defaultEncoding(fileRef) {
+    var encoding = ENCODING_BY_FILETYPE[fileRef.lastKnownFileType];
 
-    // dunno
-    return 'unknown';
-}
-
-function fileEncoding(file) {
-    if (file.lastType != BUNDLE && !file.customFramework) {
-        return DEFAULT_FILE_ENCODING;
+    if (encoding) {
+        return encoding;
     }
 }
 
-function defaultSourceTree(file) {
-    if (( file.lastType == DYLIB || file.lastType == FRAMEWORK ) && !file.customFramework) {
-        return 'SDKROOT';
-    } else {
-        return DEFAULT_SOURCE_TREE;
+function defaultGroup(fileRef) {
+    var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (!groupName) {
+        return DEFAULT_GROUP;
     }
+
+    return groupName;
 }
 
-function correctPath(file, filepath) {
-    if (file.lastType == FRAMEWORK && !file.customFramework) {
-        return 'System/Library/Frameworks/' + filepath;
-    } else if (file.lastType == DYLIB) {
-        return 'usr/lib/' + filepath;
-    } else {
-        return filepath;
+function defaultSourcetree(fileRef) {
+    var sourcetree = SOURCETREE_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (fileRef.customFramework) {
+        return filePath;
     }
+
+    if (fileRef.explicitFileType) {
+        return DEFAULT_PRODUCT_SOURCETREE;
+    }
+
+    return sourcetree;
 }
 
-function correctGroup(file) {
-    if (file.lastType == SOURCE_FILE) {
-        return 'Sources';
-    } else if (file.lastType == DYLIB || file.lastType == ARCHIVE || file.lastType == FRAMEWORK) {
-        return 'Frameworks';
-    } else {
-        return 'Resources';
+function defaultPath(fileRef, filePath) {
+    var defaultPath = PATH_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (fileRef.customFramework) {
+        return filePath;
     }
+    if (defaultPath) {
+        return path.join(defaultPath, filePath);
+    }
+
+    return filePath;
+}
+
+function defaultGroup(fileRef) {
+    var groupName = GROUP_BY_FILETYPE[fileRef.lastKnownFileType];
+
+    if (!groupName) {
+        return DEFAULT_GROUP;
+    }
+
+    return defaultGroup;
 }
 
 function pbxFile(filepath, opt) {
@@ -136,9 +152,9 @@ function pbxFile(filepath, opt) {
     this.lastType = opt.lastType || detectLastType(filepath);
 
     // for custom frameworks
-    if(opt.customFramework == true) {
-      this.customFramework = true;
-      this.dirname = path.dirname(filepath);
+    if (opt.customFramework == true) {
+        this.customFramework = true;
+        this.dirname = path.dirname(filepath);
     }
 
     this.basename = path.basename(filepath);
@@ -149,12 +165,12 @@ function pbxFile(filepath, opt) {
     this.fileEncoding = opt.fileEncoding || fileEncoding(this);
 
     if (opt.weak && opt.weak === true) 
-      this.settings = { ATTRIBUTES: ['Weak'] };
+        this.settings = { ATTRIBUTES: ['Weak'] };
 
     if (opt.compilerFlags) {
         if (!this.settings)
-          this.settings = {};
-          this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
+            this.settings = {};
+        this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
     }
 }
 

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -150,6 +150,7 @@ function pbxFile(filepath, opt) {
     var opt = opt || {};
 
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
+    this.group = defaultGroup(this);
 
     // for custom frameworks
     if (opt.customFramework == true) {
@@ -158,11 +159,21 @@ function pbxFile(filepath, opt) {
     }
 
     this.basename = path.basename(filepath);
-    this.path = correctPath(this, filepath);
-    this.group = correctGroup(this);
+    this.path = defaultPath(this, filepath);
+    this.defaultEncoding = opt.defaultEncoding || defaultEncoding(this);
 
-    this.sourceTree = opt.sourceTree || defaultSourceTree(this);
-    this.fileEncoding = opt.fileEncoding || fileEncoding(this);
+
+    // When referencing products / build output files
+    if (opt.explicitFileType) {
+        this.explicitFileType = opt.explicitFileType;
+        this.basename = this.basename + '.' + defaultExtension(this);
+        delete this.path;
+        delete this.lastKnownFileType;
+        delete this.group;
+        delete this.defaultEncoding;
+    }
+
+    this.sourceTree = opt.sourceTree || defaultSourcetree(this);
 
     if (opt.weak && opt.weak === true) 
         this.settings = { ATTRIBUTES: ['Weak'] };

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -1,14 +1,74 @@
 var path = require('path'),
-    util = require('util'),
-    M_EXTENSION = /[.]m$/, SOURCE_FILE = 'sourcecode.c.objc',
-    H_EXTENSION = /[.]h$/, HEADER_FILE = 'sourcecode.c.h',
-    BUNDLE_EXTENSION = /[.]bundle$/, BUNDLE = '"wrapper.plug-in"',
-    XIB_EXTENSION = /[.]xib$/, XIB_FILE = 'file.xib',
-    DYLIB_EXTENSION = /[.]dylib$/, DYLIB = '"compiled.mach-o.dylib"',
-    FRAMEWORK_EXTENSION = /[.]framework/, FRAMEWORK = 'wrapper.framework',
-    ARCHIVE_EXTENSION = /[.]a$/, ARCHIVE = 'archive.ar',
-    DEFAULT_SOURCE_TREE = '"<group>"',
-    DEFAULT_FILE_ENCODING = 4;
+    util = require('util');
+
+var DEFAULT_SOURCETREE = '"<group>"',
+    DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR',
+    DEFAULT_FILEENCODING = 4,
+    DEFAULT_GROUP = 'Resources',
+    DEFAULT_FILETYPE = 'unknown';
+
+var FILETYPE_BY_EXTENSION = {
+        a: 'archive.ar',
+        app: 'wrapper.application',
+        appex: 'wrapper.app-extension',
+        bundle: 'wrapper.plug-in',
+        dylib: 'compiled.mach-o.dylib',
+        framework: 'wrapper.framework',
+        h: 'sourcecode.c.h',
+        m: 'sourcecode.c.objc',
+        markdown: 'text',
+        mdimporter: 'wrapper.cfbundle',
+        octest: 'wrapper.cfbundle',
+        pch: 'sourcecode.c.h',
+        plist: 'text.plist.xml',
+        sh: 'text.script.sh',
+        swift: 'sourcecode.swift',
+        xcassets: 'folder.assetcatalog',
+        xcconfig: 'text.xcconfig',
+        xcdatamodel: 'wrapper.xcdatamodel',
+        xcodeproj: 'wrapper.pb-project',
+        xctest: 'wrapper.cfbundle',
+        xib: 'file.xib'
+    },
+    EXTENSION_BY_PRODUCTTYPE = {
+        'com.apple.product-type.application': 'app',
+        'com.apple.product-type.application.watchapp': 'app',
+        'com.apple.product-type.app-extension': 'appex',
+        'com.apple.product-type.watchkit-extension': 'appex',
+        'com.apple.product-type.bundle': 'bundle',
+        'com.apple.product-type.bundle.unit-test': 'xctest',
+        'com.apple.product-type.framework': 'framework',
+        'com.apple.product-type.library.dynamic': 'dylib',
+        'com.apple.product-type.library.static': 'a',
+        'com.apple.product-type.tool': ''
+    },
+    GROUP_BY_FILETYPE = {
+        'archive.ar': 'Frameworks',
+        'compiled.mach-o.dylib': 'Frameworks',
+        'wrapper.framework': 'Frameworks',
+        'sourcecode.c.h': 'Sources',
+        'sourcecode.c.objc': 'Sources',
+        'sourcecode.swift': 'Sources'
+    },
+    PATH_BY_FILETYPE = {
+        'compiled.mach-o.dylib': 'usr/lib/',
+        'wrapper.framework': 'System/Library/Frameworks/'
+    },
+    SOURCETREE_BY_FILETYPE = {
+        'compiled.mach-o.dylib': 'SDKROOT',
+        'wrapper.framework': 'SDKROOT'
+    },
+    ENCODING_BY_FILETYPE = {
+        'sourcecode.c.h': 4,
+        'sourcecode.c.h': 4,
+        'sourcecode.c.objc': 4,
+        'sourcecode.swift': 4,
+        'text': 4,
+        'text.plist.xml': 4,
+        'text.script.sh': 4,
+        'text.xcconfig': 4
+    };
+
 
 function detectLastType(path) {
     if (M_EXTENSION.test(path))

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -23,6 +23,7 @@ var FILETYPE_BY_EXTENSION = {
         plist: 'text.plist.xml',
         sh: 'text.script.sh',
         swift: 'sourcecode.swift',
+        tbd: 'sourcecode.text-based-dylib-definition',
         xcassets: 'folder.assetcatalog',
         xcconfig: 'text.xcconfig',
         xcdatamodel: 'wrapper.xcdatamodel',
@@ -33,6 +34,7 @@ var FILETYPE_BY_EXTENSION = {
     GROUP_BY_FILETYPE = {
         'archive.ar': 'Frameworks',
         'compiled.mach-o.dylib': 'Frameworks',
+        'sourcecode.text-based-dylib-definition': 'Frameworks',
         'wrapper.framework': 'Frameworks',
         'sourcecode.c.h': 'Resources',
         'sourcecode.c.objc': 'Sources',
@@ -40,10 +42,12 @@ var FILETYPE_BY_EXTENSION = {
     },
     PATH_BY_FILETYPE = {
         'compiled.mach-o.dylib': 'usr/lib/',
+        'sourcecode.text-based-dylib-definition': 'usr/lib/',
         'wrapper.framework': 'System/Library/Frameworks/'
     },
     SOURCETREE_BY_FILETYPE = {
         'compiled.mach-o.dylib': 'SDKROOT',
+        'sourcecode.text-based-dylib-definition': 'SDKROOT',
         'wrapper.framework': 'SDKROOT'
     },
     ENCODING_BY_FILETYPE = {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -81,8 +81,15 @@ function detectType(filePath) {
     return type;
 }
 
+function defaultExtension(fileRef) {
+    var extension = EXTENSION_BY_PRODUCTTYPE[fileRef.explicitFileType];
 
+    if (!extension) {
+        return;
+    }
 
+    return extension;
+}
 
 
     // dunno

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -149,7 +149,7 @@ function defaultGroup(fileRef) {
 function pbxFile(filepath, opt) {
     var opt = opt || {};
 
-    this.lastType = opt.lastType || detectLastType(filepath);
+    this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
 
     // for custom frameworks
     if (opt.customFramework == true) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -164,9 +164,8 @@ function defaultGroup(fileRef) {
 }
 
 function pbxFile(filepath, opt) {
-    var opt = opt || {};
-
-    self = this;
+    var opt = opt || {},
+        self = this;
 
     this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -30,18 +30,6 @@ var FILETYPE_BY_EXTENSION = {
         xctest: 'wrapper.cfbundle',
         xib: 'file.xib'
     },
-    EXTENSION_BY_PRODUCTTYPE = {
-        'com.apple.product-type.application': 'app',
-        'com.apple.product-type.application.watchapp': 'app',
-        'com.apple.product-type.app-extension': 'appex',
-        'com.apple.product-type.watchkit-extension': 'appex',
-        'com.apple.product-type.bundle': 'bundle',
-        'com.apple.product-type.bundle.unit-test': 'xctest',
-        'com.apple.product-type.framework': 'framework',
-        'com.apple.product-type.library.dynamic': 'dylib',
-        'com.apple.product-type.library.static': 'a',
-        'com.apple.product-type.tool': ''
-    },
     GROUP_BY_FILETYPE = {
         'archive.ar': 'Frameworks',
         'compiled.mach-o.dylib': 'Frameworks',
@@ -82,13 +70,14 @@ function detectType(filePath) {
 }
 
 function defaultExtension(fileRef) {
-    var extension = EXTENSION_BY_PRODUCTTYPE[fileRef.explicitFileType];
+    var filetype = fileRef.explicitFileType.replace(/^"|"$/g, '');
 
-    if (!extension) {
-        return;
+    for(var extension in FILETYPE_BY_EXTENSION) {
+        if(FILETYPE_BY_EXTENSION.hasOwnProperty(extension) ) {
+             if(FILETYPE_BY_EXTENSION[extension] === filetype )
+                 return extension;
+        }
     }
-
-    return extension;
 }
 
 function defaultEncoding(fileRef) {
@@ -175,7 +164,7 @@ function pbxFile(filepath, opt) {
 
     this.sourceTree = opt.sourceTree || defaultSourcetree(this);
 
-    if (opt.weak && opt.weak === true) 
+    if (opt.weak && opt.weak === true)
         this.settings = { ATTRIBUTES: ['Weak'] };
 
     if (opt.compilerFlags) {

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -110,18 +110,18 @@ function detectGroup(fileRef) {
 }
 
 function detectSourcetree(fileRef) {
-    
+
     var filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
 
     if (fileRef.explicitFileType) {
         return DEFAULT_PRODUCT_SOURCETREE;
     }
-    
+
     if (fileRef.customFramework) {
         return DEFAULT_SOURCETREE;
     }
-    
+
     if (!sourcetree) {
         return DEFAULT_SOURCETREE;
     }
@@ -136,7 +136,7 @@ function defaultPath(fileRef, filePath) {
     if (fileRef.customFramework) {
         return filePath;
     }
-    
+
     if (defaultPath) {
         return path.join(defaultPath, path.basename(filePath));
     }
@@ -156,7 +156,7 @@ function defaultGroup(fileRef) {
 
 function pbxFile(filepath, opt) {
     var opt = opt || {};
-    
+
     self = this;
 
     this.basename = path.basename(filepath);
@@ -193,6 +193,14 @@ function pbxFile(filepath, opt) {
         if (!this.settings)
             this.settings = {};
         this.settings.COMPILER_FLAGS = util.format('"%s"', opt.compilerFlags);
+    }
+
+    if (opt.sign) {
+      if (!this.settings)
+          this.settings = {};
+      if (!this.settings.ATTRIBUTES)
+          this.settings.ATTRIBUTES = [];
+      this.settings.ATTRIBUTES.push('CodeSignOnCopy');
     }
 }
 

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -70,27 +70,20 @@ var FILETYPE_BY_EXTENSION = {
     };
 
 
-function detectLastType(path) {
-    if (M_EXTENSION.test(path))
-        return SOURCE_FILE;
+function detectType(filePath) {
+    var extension = path.extname(filePath),
+        type = FILETYPE_BY_EXTENSION[extension];
 
-    if (H_EXTENSION.test(path))
-        return HEADER_FILE;
+    if (!type) {
+        return DEFAULT_FILETYPE;
+    }
 
-    if (BUNDLE_EXTENSION.test(path))
-        return BUNDLE;
+    return type;
+}
 
-    if (XIB_EXTENSION.test(path))
-        return XIB_FILE;
 
-    if (FRAMEWORK_EXTENSION.test(path))
-        return FRAMEWORK;
 
-    if (DYLIB_EXTENSION.test(path))
-        return DYLIB;
 
-    if (ARCHIVE_EXTENSION.test(path))
-        return ARCHIVE;
 
     // dunno
     return 'unknown';

--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -94,7 +94,7 @@ function defaultEncoding(fileRef) {
 }
 
 function detectGroup(fileRef) {
-    var extension = path.extname(this.basename).substring(1),
+    var extension = path.extname(fileRef.basename).substring(1),
         filetype = fileRef.lastKnownFileType || fileRef.explicitFileType,
         groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
 
@@ -159,6 +159,7 @@ function pbxFile(filepath, opt) {
     
     self = this;
 
+    this.basename = path.basename(filepath);
     this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
     this.group = detectGroup(self);
 
@@ -168,7 +169,6 @@ function pbxFile(filepath, opt) {
         this.dirname = path.dirname(filepath);
     }
 
-    this.basename = path.basename(filepath);
     this.path = defaultPath(this, filepath);
     this.fileEncoding = this.defaultEncoding = opt.defaultEncoding || defaultEncoding(self);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -214,7 +214,14 @@ pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
     }
 }
 
-pbxProject.prototype.addResourceFile = function(path, opt) {
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.addResourceFile = function(path, opt, group) {
     opt = opt || {};
 
     var file;
@@ -223,7 +230,7 @@ pbxProject.prototype.addResourceFile = function(path, opt) {
         file = this.addPluginFile(path, opt);
         if (!file) return false;
     } else {
-        file = new pbxFile(path, opt);
+        file = new pbxFile(path, opt);       
         if (this.hasFile(file.path)) return false;
     }
 
@@ -234,19 +241,32 @@ pbxProject.prototype.addResourceFile = function(path, opt) {
         correctForResourcesPath(file, this);
         file.fileRef = this.generateUuid();
     }
-
+    
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-
+    
     if (!opt.plugin) {
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
-        this.addToResourcesPbxGroup(file);          // PBXGroup
+        if (group) {
+            this.addToPbxGroup(file, group);            //Group other than Resources (i.e. 'splash')
+        }
+        else {
+            this.addToResourcesPbxGroup(file);          // PBXGroup
+        }
+        
     }
-
+    
     return file;
 }
 
-pbxProject.prototype.removeResourceFile = function(path, opt) {
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.removeResourceFile = function(path, opt, group) {
     var file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -254,7 +274,12 @@ pbxProject.prototype.removeResourceFile = function(path, opt) {
 
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
-    this.removeFromResourcesPbxGroup(file);          // PBXGroup
+    if (group) {
+        this.removeFromPbxGroup(file, group);           //Group other than Resources (i.e. 'splash')
+    }
+    else {
+        this.removeFromResourcesPbxGroup(file);          // PBXGroup
+    }    
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
 
     return file;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1447,6 +1447,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         command_line_tool: 'wrapper',
         dynamic_library: 'products_directory',
         framework: 'shared_frameworks',
+        frameworks: 'frameworks',
         static_library: 'products_directory',
         unit_test_bundle: 'wrapper',
         watch_app: 'wrapper',

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -850,6 +850,52 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
         }
     }
 }
+
+pbxProject.prototype.addToOtherLinkerFlags = function (flag) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        INHERITED = '"$(inherited)"',
+        OTHER_LDFLAGS = 'OTHER_LDFLAGS',
+        config, buildSettings;
+
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
+
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName)
+            continue;
+
+        if (!buildSettings[OTHER_LDFLAGS]
+                || buildSettings[OTHER_LDFLAGS] === INHERITED) {
+            buildSettings[OTHER_LDFLAGS] = [INHERITED];
+        }
+
+        buildSettings[OTHER_LDFLAGS].push(flag);
+    }
+}
+
+pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        OTHER_LDFLAGS = 'OTHER_LDFLAGS',
+        config, buildSettings;
+    
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
+        
+        if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
+            continue;
+        }
+        
+        if (buildSettings[OTHER_LDFLAGS]) {
+            var matches = buildSettings[OTHER_LDFLAGS].filter(function (p) {
+                return p.indexOf(flag) > -1;
+            });
+            matches.forEach(function (m) {
+                var idx = buildSettings[OTHER_LDFLAGS].indexOf(m);
+                buildSettings[OTHER_LDFLAGS].splice(idx, 1);
+            });
+        }
+    }
+}
+
 // a JS getter. hmmm
 pbxProject.prototype.__defineGetter__("productName", function () {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -325,6 +325,21 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
     return {uuid: pbxGroupUuid, pbxGroup: pbxGroup};
 }
 
+pbxProject.prototype.removePbxGroup = function (groupName) {
+    var section = this.hash.project.objects['PBXGroup'],
+        key, itemKey;
+
+    for (key in section) {
+        // only look for comments
+        if (!COMMENT_KEY.test(key)) continue;
+
+        if (section[key] == groupName) {
+            itemKey = key.split(COMMENT_KEY)[0];
+            delete section[itemKey];
+        }
+    }
+}
+
 pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
     var commentKey = f("%s_comment", file.fileRef);
 
@@ -333,22 +348,26 @@ pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
 }
 
 pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
-
-    var i;
     var refObj = pbxFileReferenceObj(file);
-    for(i in this.pbxFileReferenceSection()) {
-        if(this.pbxFileReferenceSection()[i].name == refObj.name ||
-           ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
-           this.pbxFileReferenceSection()[i].path == refObj.path ||
-           ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
+    var pbxFileReferenceSection = this.pbxFileReferenceSection();
+    for (var i in pbxFileReferenceSection) {
+        var pbxFileReferenceSectionName = quote(pbxFileReferenceSection[i].name);
+        var pbxFileReferenceSectionPath = quote(pbxFileReferenceSection[i].path);
+        var refObjName = quote(refObj.name);
+        var refObjPath = quote(refObj.path);
+        if (pbxFileReferenceSectionName == refObjName ||
+            pbxFileReferenceSectionName == refObjPath ||
+            pbxFileReferenceSectionPath == refObjPath ||
+            pbxFileReferenceSectionPath == refObjName) {
             file.fileRef = file.uuid = i;
-            delete this.pbxFileReferenceSection()[i];
+            delete pbxFileReferenceSection[i];
             break;
         }
     }
-    var commentKey = f("%s_comment", file.fileRef);
-    if(this.pbxFileReferenceSection()[commentKey] != undefined) {
-        delete this.pbxFileReferenceSection()[commentKey];
+    
+    if (typeof file.fileRef !== 'undefined') {
+        var commentKey = f("%s_comment", file.fileRef);
+        delete pbxFileReferenceSection[commentKey];
     }
 
     return file;
@@ -376,11 +395,13 @@ pbxProject.prototype.addToResourcesPbxGroup = function (file) {
 }
 
 pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
-    var pluginsGroupChildren = this.pbxGroupByName('Resources').children, i;
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
-            pluginsGroupChildren.splice(i, 1);
+    var groupChild = pbxGroupChild(file);
+    var resourcesGroupChildren = this.pbxGroupByName('Resources').children;
+    for (var i in resourcesGroupChildren) {
+        var resourcesGroupChild = resourcesGroupChildren[i];
+        if ((typeof groupChild.value === 'undefined' || groupChild.value == resourcesGroupChild.value) &&
+            groupChild.comment == resourcesGroupChild.comment) {
+            resourcesGroupChildren.splice(i, 1);
             break;
         }
     }
@@ -1084,6 +1105,10 @@ function nonComments(obj) {
 
 function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
+}
+
+function quote(str) {
+    if (str) return '"' + unquote(str) + '"';
 }
 
 module.exports = pbxProject;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1050,7 +1050,6 @@ function pbxFileReferenceObj(file) {
     var obj = Object.create(null);
 
     obj.isa = 'PBXFileReference';
-    obj.lastKnownFileType = file.lastType;
 
     obj.name = "\"" + file.basename + "\"";
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -245,6 +245,59 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     return file;
 }
 
+
+pbxProject.prototype.addCopyfile = function(fpath, opt) {
+    var file = new pbxFile(fpath, opt);
+
+    // catch duplicates
+    if (this.hasFile(file.path)) {
+        file = this.hasFile(file.path);
+    } else {
+        file.uuid = this.generateUuid();
+        file.fileRef = this.generateUuid();
+    }
+
+    file.target = opt ? opt.target : undefined;
+    file.group = 'CopyFiles';
+
+
+    this.addToPbxBuildFileSection(file);        // PBXBuildFile
+    this.addToPbxFileReferenceSection(file);    // PBXFileReference
+    this.addToPbxCopyfilesBuildPhase(file);     // PBXCopyFilesBuildPhase
+
+    return file;
+}
+
+pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', target);
+}
+
+pbxProject.prototype.addToPbxCopyfilesBuildPhase = function(file) {
+    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', file.target);
+    sources.files.push(pbxBuildPhaseObj(file));
+}
+
+pbxProject.prototype.removeCopyfile = function(fpath, opt) {
+    var file = new pbxFile(fpath, opt);
+    file.target = opt ? opt.target : undefined;
+
+    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromPbxCopyfilesBuildPhase(file);    // PBXFrameworksBuildPhase
+
+    return file;
+}
+
+pbxProject.prototype.removeFromPbxCopyfilesBuildPhase = function(file) {
+    var sources = this.pbxCopyfilesBuildPhaseObj(file.target);
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
+            sources.files.splice(i, 1);
+            break;
+        }
+    }
+}
+
 pbxProject.prototype.addStaticLibrary = function(path, opt) {
     opt = opt || {};
 
@@ -1114,6 +1167,42 @@ function pbxBuildPhaseObj(file) {
 
     obj.value = file.uuid;
     obj.comment = longComment(file);
+
+    return obj;
+}
+
+function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
+
+     // Add additional properties for 'CopyFiles' build phase
+    var DESTINATION_BY_TARGETTYPE = {
+        application: 'wrapper',
+        app_extension: 'plugins',
+        bundle: 'wrapper',
+        command_line_tool: 'wrapper',
+        dynamic_library: 'products_directory',
+        framework: 'shared_frameworks',
+        static_library: 'products_directory',
+        unit_test_bundle: 'wrapper',
+        watch_app: 'wrapper',
+        watch_extension: 'plugins'
+    }
+    var SUBFOLDERSPEC_BY_DESTINATION = {
+        absolute_path: 0,
+        executables: 6,
+        frameworks: 10,
+        java_resources: 15,
+        plugins: 13,
+        products_directory: 16,
+        resources: 7,
+        shared_frameworks: 11,
+        shared_support: 12,
+        wrapper: 1,
+        xpc_services: 0
+    }
+
+    obj.name = phaseName || '""';
+    obj.dstPath = subfolderPath || '""';
+    obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 
     return obj;
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -8,6 +8,7 @@ var util = require('util'),
     pbxFile = require('./pbxFile'),
     fs = require('fs'),
     parser = require('./parser/pbxproj'),
+    plist = require('simple-plist'),
     COMMENT_KEY = /_comment$/
 
 function pbxProject(filename) {
@@ -507,6 +508,26 @@ pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
     return file;
 }
 
+pbxProject.prototype.addToXcVersionGroupSection = function(file) {
+    if (!file.models || !file.currentModel) {
+        throw new Error("Cannot create a XCVersionGroup section from not a data model document file");
+    }
+
+    var commentKey = f("%s_comment", file.fileRef);
+
+    if (!this.xcVersionGroupSection()[file.fileRef]) {
+        this.xcVersionGroupSection()[file.fileRef] = {
+            isa: 'XCVersionGroup',
+            children: file.models.map(function (el) { return el.fileRef; }),
+            currentVersion: file.currentModel.fileRef,
+            path: file.path,
+            sourceTree: '"<group>"',
+            versionGroupType: 'wrapper.xcdatamodel'
+        };
+        this.xcVersionGroupSection()[commentKey] = path.basename(file.path);
+    }
+}
+
 pbxProject.prototype.addToPluginsPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Plugins');
     pluginsGroup.children.push(pbxGroupChild(file));
@@ -805,7 +826,7 @@ pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
-pbxProject.prototype.pbxVersionGroupSection = function () {
+pbxProject.prototype.xcVersionGroupSection = function () {
     if (typeof this.hash.project.objects['XCVersionGroup'] !== 'object') {
         this.hash.project.objects['XCVersionGroup'] = {};
     }
@@ -836,6 +857,22 @@ pbxProject.prototype.pbxGroupByName = function(name) {
 
 pbxProject.prototype.pbxTargetByName = function(name) {
     return this.pbxItemByComment(name, 'PBXNativeTarget');
+}
+
+pbxProject.prototype.findTargetKey = function(name) {
+    var targets = this.hash.project.objects['PBXNativeTarget'];
+
+    for (var key in targets) {
+        // only look for comments
+        if (COMMENT_KEY.test(key)) continue;
+
+        var target = targets[key];
+        if (target.name === name) {
+            return key;
+        }
+    }
+
+    return null;
 }
 
 pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
@@ -1710,6 +1747,62 @@ pbxProject.prototype.getBuildConfigByName = function(name) {
         }
     }
     return target;
+}
+
+pbxProject.prototype.addDataModelDocument = function(filePath, group, opt) {
+    if (!group) {
+        group = 'Resources';
+    }
+    if (!this.getPBXGroupByKey(group)) {
+        group = this.findPBXGroupKey({ name: group });
+    }
+
+    var file = new pbxFile(filePath, opt);
+
+    if (!file || this.hasFile(file.path)) return null;
+
+    file.fileRef = this.generateUuid();
+    this.addToPbxGroup(file, group);
+
+    if (!file) return false;
+
+    file.target = opt ? opt.target : undefined;
+    file.uuid = this.generateUuid();
+
+    this.addToPbxBuildFileSection(file);
+    this.addToPbxSourcesBuildPhase(file);
+
+    file.models = [];
+    var currentVersionName;
+    var modelFiles = fs.readdirSync(file.path);
+    for (var index in modelFiles) {
+        var modelFileName = modelFiles[index];
+        var modelFilePath = path.join(filePath, modelFileName);
+
+        if (modelFileName == '.xccurrentversion') {
+            currentVersionName = plist.readFileSync(modelFilePath)._XCCurrentVersionName;
+            continue;
+        }
+
+        var modelFile = new pbxFile(modelFilePath);
+        modelFile.fileRef = this.generateUuid();
+
+        this.addToPbxFileReferenceSection(modelFile);
+
+        file.models.push(modelFile);
+
+        if (currentVersionName && currentVersionName === modelFileName) {
+            file.currentModel = modelFile;
+        }
+    }
+
+    if (!file.currentModel) {
+        file.currentModel = file.models[0];
+    }
+
+    this.addToXcVersionGroupSection(file);
+
+    return file;
 }
 
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -326,6 +326,7 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
         this.removeFromFrameworkSearchPaths(file);
     }
 
+    opt = opt || {};
     opt.embed = true;
     var embeddedFile = new pbxFile(fpath, opt);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -261,6 +261,13 @@ pbxProject.prototype.removeResourceFile = function(path, opt) {
 }
 
 pbxProject.prototype.addFramework = function(fpath, opt) {
+    var customFramework = opt && opt.customFramework == true;
+    var link = !opt || (opt.link == undefined || opt.link);    //defaults to true if not specified
+    var embed = opt && opt.embed;                              //defaults to false if not specified
+
+    if (opt) {
+      delete opt.embed;
+    }
 
     var file = new pbxFile(fpath, opt);
 
@@ -269,10 +276,6 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     file.target = opt ? opt.target : undefined;
 
     if (this.hasFile(file.path)) return false;
-
-    var customFramework = opt && opt.customFramework == true;
-    var link = !opt || (opt.link == undefined || opt.link);    //defaults to true if not specified
-    var embed = opt && opt.embed;                              //defaults to false if not specified
 
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
@@ -286,7 +289,18 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
         this.addToFrameworkSearchPaths(file);
 
         if (embed) {
-          this.addToPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
+          opt.embed = embed;
+          var embeddedFile = new pbxFile(fpath, opt);
+
+          embeddedFile.uuid = this.generateUuid();
+          embeddedFile.fileRef = file.fileRef;
+
+          //keeping a separate PBXBuildFile entry for Embed Frameworks
+          this.addToPbxBuildFileSection(embeddedFile);        // PBXBuildFile
+
+          this.addToPbxEmbedFrameworksBuildPhase(embeddedFile); // PBXCopyFilesBuildPhase
+
+          return embeddedFile;
         }
     }
 
@@ -294,6 +308,12 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
 }
 
 pbxProject.prototype.removeFramework = function(fpath, opt) {
+    var embed = opt && opt.embed;
+
+    if (opt) {
+      delete opt.embed;
+    }
+
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -301,11 +321,18 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     this.removeFromPbxFileReferenceSection(file);      // PBXFileReference
     this.removeFromFrameworksPbxGroup(file);           // PBXGroup
     this.removeFromPbxFrameworksBuildPhase(file);      // PBXFrameworksBuildPhase
-    this.removeFromPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
 
     if (opt && opt.customFramework) {
         this.removeFromFrameworkSearchPaths(path.dirname(fpath));
     }
+
+    opt.embed = true;
+    var embeddedFile = new pbxFile(fpath, opt);
+
+    embeddedFile.fileRef = file.fileRef;
+
+    this.removeFromPbxBuildFileSection(embeddedFile);          // PBXBuildFile
+    this.removeFromPbxEmbedFrameworksBuildPhase(embeddedFile); // PBXCopyFilesBuildPhase
 
     return file;
 }
@@ -600,12 +627,13 @@ pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
 pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
     var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
     if (sources) {
+        var files = [];
         for (i in sources.files) {
-            if (sources.files[i].comment == longComment(file)) {
-                sources.files.splice(i, 1);
-                break;
+            if (sources.files[i].comment != longComment(file)) {
+                files.push(sources.files[i]);
             }
         }
+        sources.files = files;
     }
 }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -230,7 +230,7 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         file = this.addPluginFile(path, opt);
         if (!file) return false;
     } else {
-        file = new pbxFile(path, opt);       
+        file = new pbxFile(path, opt);
         if (this.hasFile(file.path)) return false;
     }
 
@@ -241,10 +241,10 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         correctForResourcesPath(file, this);
         file.fileRef = this.generateUuid();
     }
-    
+
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-    
+
     if (!opt.plugin) {
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         if (group) {
@@ -253,9 +253,9 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         else {
             this.addToResourcesPbxGroup(file);          // PBXGroup
         }
-        
+
     }
-    
+
     return file;
 }
 
@@ -279,7 +279,7 @@ pbxProject.prototype.removeResourceFile = function(path, opt, group) {
     }
     else {
         this.removeFromResourcesPbxGroup(file);          // PBXGroup
-    }    
+    }
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
 
     return file;
@@ -909,6 +909,11 @@ pbxProject.prototype.pbxFileReferenceSection = function() {
 
 pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
+}
+
+// Keep this method for backwards compatibility.
+pbxProject.prototype.pbxNativeTarget = function() {
+    return this.pbxNativeTargetSection();
 }
 
 pbxProject.prototype.xcVersionGroupSection = function () {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1097,7 +1097,7 @@ function pbxBuildFileComment(file) {
 }
 
 function pbxFileReferenceComment(file) {
-    return path.basename(file.path);
+    return file.basename || path.basename(file.path);
 }
 
 function pbxNativeTargetComment(target) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -926,7 +926,7 @@ pbxProject.prototype.hasFile = function(filePath) {
     for (id in files) {
         file = files[id];
         if (file.path == filePath || file.path == ('"' + filePath + '"')) {
-            return true;
+            return file;
         }
     }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -642,15 +642,14 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
-    var buildPhaseSection,
+pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment, folderType, subfolderPath) {
+    var buildPhaseSection = this.hash.project.objects[addToType],
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
-        buildPhaseUuid = this.generateUuid(),
-        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
-        commentKey = f("%s_comment", buildPhaseUuid),
-        buildPhase = {
-            isa: buildPhaseType,
+        phaseUuid = this.generateUuid(),
+        commentKey = f("%s_comment", phaseUuid),
+        buildPhaseRef = {
+            isa: addToType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
@@ -658,28 +657,10 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
         filePathToBuildFile = {};
 
 
-    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
-        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
-        buildPhase.name = comment;
+    // Add CopyFiles BuildPhase template
+    if (addToType === 'PBXCopyFilesBuildPhase') {
+        buildPhaseRef = pbxCopyFilesBuildPhaseObj(buildPhaseRef, folderType, subfolderPath, comment);
     }
-
-    if (!this.hash.project.objects[buildPhaseType]) {
-        this.hash.project.objects[buildPhaseType] = new Object();
-        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
-        this.hash.project.objects[buildPhaseType][commentKey] = comment;
-
-
-        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
-            value: buildPhaseUuid,
-            comment: comment
-        })
-
-                console.log(util.inspect(this.hash.project.objects['PBXNativeTarget'], true, null));
-
-    }
-
-
-    buildPhase = this.hash.project.objects[buildPhaseType];
 
 
     for (var key in buildFileSection) {
@@ -714,15 +695,15 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, co
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
-        buildPhase.files.push(pbxBuildPhaseObj(file));
+        buildPhaseRef.files.push(pbxBuildPhaseObj(file));
     }
 
     if (buildPhaseSection) {
-        buildPhaseSection[buildPhaseUuid] = buildPhase;
+        buildPhaseSection[phaseUuid] = buildPhaseRef;
         buildPhaseSection[commentKey] = comment;
-    }
+        }
 
-    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
+    return { uuid: phaseUuid, buildPhase: buildPhaseRef };
 }
 
 // helper access functions
@@ -1083,8 +1064,7 @@ pbxProject.prototype.addTarget = function(name, type) {
     if (targetType === 'app_extension') {
         // Create "Copy Files" build phase for target which contains the extension
         this.addToPbxBuildFileSection(productFile);
-        var newPhase = this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
-        this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+        this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
     };
 
     // Target: Add uuid to root project
@@ -1200,7 +1180,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         xpc_services: 0
     }
 
-    obj.name = phaseName || '""';
+    obj.name = '"' + phaseName + '"' || '""';
     obj.dstPath = subfolderPath || '""';
     obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -805,6 +805,14 @@ pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
+pbxProject.prototype.pbxVersionGroupSection = function () {
+    if (typeof this.hash.project.objects['XCVersionGroup'] !== 'object') {
+        this.hash.project.objects['XCVersionGroup'] = {};
+    }
+
+    return this.hash.project.objects['XCVersionGroup'];
+}
+
 pbxProject.prototype.pbxXCConfigurationList = function() {
     return this.hash.project.objects['XCConfigurationList'];
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -270,13 +270,24 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
 
     if (this.hasFile(file.path)) return false;
 
+    var customFramework = opt && opt.customFramework == true;
+    var link = !opt || (opt.link == undefined || opt.link);    //defaults to true if not specified
+    var embed = opt && opt.embed;                              //defaults to false if not specified
+
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
     this.addToFrameworksPbxGroup(file);         // PBXGroup
-    this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
 
-    if (opt && opt.customFramework == true) {
+    if (link) {
+      this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
+    }
+
+    if (customFramework) {
         this.addToFrameworkSearchPaths(file);
+
+        if (embed) {
+          this.addToPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
+        }
     }
 
     return file;
@@ -286,10 +297,11 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
-    this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
-    this.removeFromFrameworksPbxGroup(file);         // PBXGroup
-    this.removeFromPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
+    this.removeFromPbxBuildFileSection(file);          // PBXBuildFile
+    this.removeFromPbxFileReferenceSection(file);      // PBXFileReference
+    this.removeFromFrameworksPbxGroup(file);           // PBXGroup
+    this.removeFromPbxFrameworksBuildPhase(file);      // PBXFrameworksBuildPhase
+    this.removeFromPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
 
     if (opt && opt.customFramework) {
         this.removeFromFrameworkSearchPaths(path.dirname(fpath));
@@ -578,6 +590,24 @@ pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
     }
 }
 
+pbxProject.prototype.addToPbxEmbedFrameworksBuildPhase = function (file) {
+    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
+    if (sources) {
+        sources.files.push(pbxBuildPhaseObj(file));
+    }
+}
+
+pbxProject.prototype.removeFromPbxEmbedFrameworksBuildPhase = function (file) {
+    var sources = this.pbxEmbedFrameworksBuildPhaseObj(file.target);
+    if (sources) {
+        for (i in sources.files) {
+            if (sources.files[i].comment == longComment(file)) {
+                sources.files.splice(i, 1);
+                break;
+            }
+        }
+    }
+}
 
 pbxProject.prototype.addToProductsPbxGroup = function(file) {
     var productsGroup = this.pbxGroupByName('Products');
@@ -905,6 +935,10 @@ pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
     return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
 }
 
+pbxProject.prototype.pbxEmbedFrameworksBuildPhaseObj = function (target) {
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
+};
+
 // Find Build Phase from group/target
 pbxProject.prototype.buildPhase = function(group, target) {
 
@@ -1166,14 +1200,14 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         OTHER_LDFLAGS = 'OTHER_LDFLAGS',
         config, buildSettings;
-    
+
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
-        
+
         if (unquote(buildSettings['PRODUCT_NAME']) != this.productName) {
             continue;
         }
-        
+
         if (buildSettings[OTHER_LDFLAGS]) {
             var matches = buildSettings[OTHER_LDFLAGS].filter(function (p) {
                 return p.indexOf(flag) > -1;
@@ -1192,7 +1226,7 @@ pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
-        
+
         buildSettings[buildSetting] = value;
     }
 }
@@ -1203,7 +1237,7 @@ pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
-        
+
         if (buildSettings[buildSetting]) {
             delete buildSettings[buildSetting];
         }
@@ -1245,22 +1279,22 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
         targetType = type,
         targetSubfolder = subfolder || name,
         targetName = name.trim();
-        
+
     // Check type against list of allowed target types
     if (!targetName) {
         throw new Error("Target name missing.");
-    }    
+    }
 
     // Check type against list of allowed target types
     if (!targetType) {
         throw new Error("Target type missing.");
-    } 
+    }
 
     // Check type against list of allowed target types
     if (!producttypeForTargettype(targetType)) {
         throw new Error("Target type invalid: " + targetType);
     }
-    
+
     // Build Configuration: Create
     var buildConfigurationsList = [
         {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -355,6 +355,13 @@ pbxProject.prototype.addToPbxProjectSection = function(target) {
     this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(newTarget);
 }
 
+pbxProject.prototype.addToPbxNativeTargetSection = function(target) {
+    var commentKey = f("%s_comment", target.uuid);
+
+    this.pbxNativeTargetSection()[target.uuid] = target.pbxNativeTarget;
+    this.pbxNativeTargetSection()[commentKey] = target.pbxNativeTarget.name;
+}
+
 pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -113,8 +113,9 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
 
     file.includeInIndex = 0;
     file.fileRef = this.generateUuid();
+    file.target = opt ? opt.target : undefined;
+    file.group = opt ? opt.group : undefined;
 
-    this.addToPbxFileReferenceSection(file);         // PBXFileReference
     this.addToProductsPbxGroup(file);                // PBXGroup
 
     return file;
@@ -123,7 +124,6 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
 pbxProject.prototype.removeProductFile = function(path, opt) {
     var file = new pbxFile(path, opt);
 
-    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromProductsPbxGroup(file);           // PBXGroup
 
     return file;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -304,7 +304,7 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     this.removeFromPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
 
     if (opt && opt.customFramework) {
-        this.removeFromFrameworkSearchPaths(file.dirname);
+        this.removeFromFrameworkSearchPaths(file);
     }
 
     return file;
@@ -1051,7 +1051,6 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
                 searchPaths.splice(idx, 1);
             });
         }
-
     }
 }
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1032,7 +1032,7 @@ pbxProject.prototype.addTarget = function(name, type) {
             isa: 'XCBuildConfiguration',
             buildSettings: {
                 GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-                INFOPLIST_FILE: targetName + '-Info.Plist',
+                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: targetName,
                 SKIP_INSTALL: 'YES'
@@ -1042,7 +1042,7 @@ pbxProject.prototype.addTarget = function(name, type) {
             name: 'Release',
             isa: 'XCBuildConfiguration',
             buildSettings: {
-                INFOPLIST_FILE: targetName + '-Info.Plist',
+                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
                 PRODUCT_NAME: targetName,
                 SKIP_INSTALL: 'YES'

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1300,6 +1300,24 @@ function producttypeForTargettype (targetType) {
     return PRODUCTTYPE_BY_TARGETTYPE[targetType]
 }
 
+function filetypeForProducttype (productType) {
+
+    FILETYPE_BY_PRODUCTTYPE = {
+            'com.apple.product-type.application': '"wrapper.application"',
+            'com.apple.product-type.app-extension': '"wrapper.app-extension"',
+            'com.apple.product-type.bundle': '"wrapper.plug-in"',
+            'com.apple.product-type.tool': '"compiled.mach-o.dylib"',
+            'com.apple.product-type.library.dynamic': '"compiled.mach-o.dylib"',
+            'com.apple.product-type.framework': '"wrapper.framework"',
+            'com.apple.product-type.library.static': '"archive.ar"',
+            'com.apple.product-type.bundle.unit-test': '"wrapper.cfbundle"',
+            'com.apple.product-type.application.watchapp': '"wrapper.application"',
+            'com.apple.product-type.watchkit-extension': '"wrapper.app-extension"'
+        };
+
+    return FILETYPE_BY_PRODUCTTYPE[productType]
+}
+
 pbxProject.prototype.getFirstProject = function() {
 
     // Get pbxProject container

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -115,7 +115,10 @@ pbxProject.prototype.addProductFile = function(targetPath, opt) {
     file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
     file.group = opt ? opt.group : undefined;
+    file.uuid = this.generateUuid();
+    file.path = file.basename;
 
+    this.addToPbxFileReferenceSection(file);
     this.addToProductsPbxGroup(file);                // PBXGroup
 
     return file;
@@ -208,9 +211,8 @@ pbxProject.prototype.removeResourceFile = function(path, opt) {
 }
 
 pbxProject.prototype.addFramework = function(fpath, opt) {
+
     var file = new pbxFile(fpath, opt);
-    // catch duplicates
-    if (this.hasFile(file.path)) return false;
 
     file.uuid = this.generateUuid();
     file.fileRef = this.generateUuid();
@@ -252,14 +254,10 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
     // catch duplicates
     if (this.hasFile(file.path)) {
         file = this.hasFile(file.path);
-    } else {
-        file.uuid = this.generateUuid();
-        file.fileRef = this.generateUuid();
     }
 
+    file.fileRef = file.uuid = this.generateUuid();
     file.target = opt ? opt.target : undefined;
-    file.group = 'CopyFiles';
-
 
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
@@ -269,11 +267,11 @@ pbxProject.prototype.addCopyfile = function(fpath, opt) {
 }
 
 pbxProject.prototype.pbxCopyfilesBuildPhaseObj = function(target) {
-    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', target);
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', target);
 }
 
 pbxProject.prototype.addToPbxCopyfilesBuildPhase = function(file) {
-    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'CopyFiles', file.target);
+    var sources = this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
@@ -642,24 +640,40 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment, folderType, subfolderPath) {
-    var buildPhaseSection = this.hash.project.objects[addToType],
+pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
+    var buildPhaseSection,
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
-        phaseUuid = this.generateUuid(),
-        commentKey = f("%s_comment", phaseUuid),
-        buildPhaseRef = {
-            isa: addToType,
+        buildPhaseUuid = this.generateUuid(),
+        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
+        commentKey = f("%s_comment", buildPhaseUuid),
+        buildPhase = {
+            isa: buildPhaseType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
 
+    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
+        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
+    }
 
-    // Add CopyFiles BuildPhase template
-    if (addToType === 'PBXCopyFilesBuildPhase') {
-        buildPhaseRef = pbxCopyFilesBuildPhaseObj(buildPhaseRef, folderType, subfolderPath, comment);
+    if (!this.hash.project.objects[buildPhaseType]) {
+        this.hash.project.objects[buildPhaseType] = new Object();
+    }
+
+    if (!this.hash.project.objects[buildPhaseType][buildPhaseUuid]) {
+        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
+        this.hash.project.objects[buildPhaseType][commentKey] = comment;
+    }
+
+    if (this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases']) {
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
+            value: buildPhaseUuid,
+            comment: comment
+        })
+
     }
 
 
@@ -695,15 +709,15 @@ pbxProject.prototype.addBuildPhase = function(filePathsArray, addToType, comment
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
-        buildPhaseRef.files.push(pbxBuildPhaseObj(file));
+        buildPhase.files.push(pbxBuildPhaseObj(file));
     }
 
     if (buildPhaseSection) {
-        buildPhaseSection[phaseUuid] = buildPhaseRef;
+        buildPhaseSection[buildPhaseUuid] = buildPhase;
         buildPhaseSection[commentKey] = comment;
-        }
+    }
 
-    return { uuid: phaseUuid, buildPhase: buildPhaseRef };
+    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
 }
 
 // helper access functions
@@ -993,11 +1007,12 @@ pbxProject.prototype.hasFile = function(filePath) {
     return false;
 }
 
-pbxProject.prototype.addTarget = function(name, type) {
+pbxProject.prototype.addTarget = function(name, type, subfolder) {
 
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
+        targetSubfolder = subfolder,
         targetName = name.trim();
 
     // Check type against list of allowed target types
@@ -1013,9 +1028,9 @@ pbxProject.prototype.addTarget = function(name, type) {
             isa: 'XCBuildConfiguration',
             buildSettings: {
                 GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
-                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
+                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-                PRODUCT_NAME: targetName,
+                PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
         },
@@ -1023,9 +1038,9 @@ pbxProject.prototype.addTarget = function(name, type) {
             name: 'Release',
             isa: 'XCBuildConfiguration',
             buildSettings: {
-                INFOPLIST_FILE: '"' + path.join(targetName, targetName + '-Info.plist' + '"'),
+                INFOPLIST_FILE: '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist' + '"'),
                 LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
-                PRODUCT_NAME: targetName,
+                PRODUCT_NAME: '"' + targetName + '"',
                 SKIP_INSTALL: 'YES'
             }
         }
@@ -1038,16 +1053,20 @@ pbxProject.prototype.addTarget = function(name, type) {
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
         productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, { 'target': targetUuid,  'explicitFileType': productFileType}),
+        productFile = this.addProductFile(productName, { group: 'Copy Files', 'target': targetUuid, 'explicitFileType': productFileType}),
         productFileName = productFile.basename;
+
+
+    // Product: Add to build file list
+    this.addToPbxBuildFileSection(productFile);
 
     // Target: Create
     var target = {
             uuid: targetUuid,
             pbxNativeTarget: {
                 isa: 'PBXNativeTarget',
-                name: targetName,
-                productName: targetName,
+                name: '"' + targetName + '"',
+                productName: '"' + targetName + '"',
                 productReference: productFile.fileRef,
                 productType: '"' + producttypeForTargettype(targetType) + '"',
                 buildConfigurationList: buildConfigurations.uuid,
@@ -1062,9 +1081,15 @@ pbxProject.prototype.addTarget = function(name, type) {
 
     // Product: Embed (only for "extension"-type targets)
     if (targetType === 'app_extension') {
-        // Create "Copy Files" build phase for target which contains the extension
-        this.addToPbxBuildFileSection(productFile);
-        this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
+
+        // Create CopyFiles phase in first target
+        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'Copy Files', this.getFirstTarget().uuid,  targetType)
+
+        // Add product to CopyFiles phase
+        this.addToPbxCopyfilesBuildPhase(productFile)
+
+       // this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+
     };
 
     // Target: Add uuid to root project
@@ -1180,7 +1205,7 @@ function pbxCopyFilesBuildPhaseObj(obj, folderType, subfolderPath, phaseName){
         xpc_services: 0
     }
 
-    obj.name = '"' + phaseName + '"' || '""';
+    obj.name = '"' + phaseName + '"';
     obj.dstPath = subfolderPath || '""';
     obj.dstSubfolderSpec = SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType]];
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1051,21 +1051,23 @@ pbxProject.prototype.addTarget = function(name, type) {
     ];
 
     // Build Configuration: Add
-    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"'),
-        buildConfigurationsUuid = buildConfigurations.uuid;
+    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"');
 
     // Product: Create
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
-        productFile = this.addProductFile(productName, { 'explicitFileType': productType }),
+        productFileType = filetypeForProducttype(productType),
+        productFile = this.addProductFile(productName, { 'target': targetUuid, 'group': 'CopyFiles' }),
         productFileName = productFile.basename;
 
-    // Product: Embed in first target (only for "extension"-type targets)
+    // Product: Embed (only for "extension"-type targets)
     if (targetType === 'app_extension') {
-        var embedPhase;
-        var embedFile;
 
-        // TODO: Add embedding via "PBXCopyFilesBuildPhase" build phase
+        // Create "Copy Files" build phase for target which contains the extension
+        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'CopyFiles', this.getFirstTarget().uuid)
+
+        // Add product reference to "Copy Files" build phase
+        this.addCopyfile(productFileName, { 'explicitFileType': productFileType, 'target': this.getFirstTarget().uuid })
     };
 
     // Target: Create
@@ -1077,7 +1079,7 @@ pbxProject.prototype.addTarget = function(name, type) {
                 productName: targetName,
                 productReference: productFile.fileRef,
                 productType: '"' + producttypeForTargettype(targetType) + '"',
-                buildConfigurationList: buildConfigurationsUuid,
+                buildConfigurationList: buildConfigurations.uuid,
                 buildPhases: [],
                 buildRules: [],
                 dependencies: []

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -662,7 +662,7 @@ pbxProject.prototype.pbxFileReferenceSection = function() {
     return this.hash.project.objects['PBXFileReference'];
 }
 
-pbxProject.prototype.pbxNativeTarget = function () {
+pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
@@ -713,7 +713,7 @@ pbxProject.prototype.buildPhase = function(group, target) {
     if (!target)
         return undefined;
 
-     var nativeTargets = this.pbxNativeTarget();
+    var nativeTargets = this.pbxNativeTargetSection();
      if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -589,19 +589,45 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     return { uuid: target, target: nativeTargets[target] };
 }
 
-pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
-    var section = this.hash.project.objects[isa],
+pbxProject.prototype.addBuildPhase = function(filePathsArray, buildPhaseType, comment, target, folderType, subfolderPath) {
+    var buildPhaseSection,
         fileReferenceSection = this.pbxFileReferenceSection(),
         buildFileSection = this.pbxBuildFileSection(),
         buildPhaseUuid = this.generateUuid(),
+        buildPhaseTargetUuid = target || this.getFirstTarget().uuid,
         commentKey = f("%s_comment", buildPhaseUuid),
         buildPhase = {
-            isa: isa,
+            isa: buildPhaseType,
             buildActionMask: 2147483647,
             files: [],
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
+
+
+    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
+        buildPhase = pbxCopyFilesBuildPhaseObj(buildPhase, folderType, subfolderPath, comment);
+        buildPhase.name = comment;
+    }
+
+    if (!this.hash.project.objects[buildPhaseType]) {
+        this.hash.project.objects[buildPhaseType] = new Object();
+        this.hash.project.objects[buildPhaseType][buildPhaseUuid] = buildPhase;
+        this.hash.project.objects[buildPhaseType][commentKey] = comment;
+
+
+        this.hash.project.objects['PBXNativeTarget'][buildPhaseTargetUuid]['buildPhases'].push({
+            value: buildPhaseUuid,
+            comment: comment
+        })
+
+                console.log(util.inspect(this.hash.project.objects['PBXNativeTarget'], true, null));
+
+    }
+
+
+    buildPhase = this.hash.project.objects[buildPhaseType];
+
 
     for (var key in buildFileSection) {
         // only look for comments
@@ -638,9 +664,9 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
         buildPhase.files.push(pbxBuildPhaseObj(file));
     }
 
-    if (section) {
-        section[buildPhaseUuid] = buildPhase;
-        section[commentKey] = comment;
+    if (buildPhaseSection) {
+        buildPhaseSection[buildPhaseUuid] = buildPhase;
+        buildPhaseSection[commentKey] = comment;
     }
 
     return { uuid: buildPhaseUuid, buildPhase: buildPhase };

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -19,10 +19,10 @@ function pbxProject(filename) {
 
 util.inherits(pbxProject, EventEmitter)
 
-pbxProject.prototype.parse = function (cb) {
+pbxProject.prototype.parse = function(cb) {
     var worker = fork(__dirname + '/parseJob.js', [this.filepath])
 
-    worker.on('message', function (msg) {
+    worker.on('message', function(msg) {
         if (msg.name == 'SyntaxError' || msg.code) {
             this.emit('error', msg);
         } else {
@@ -39,19 +39,19 @@ pbxProject.prototype.parse = function (cb) {
     return this;
 }
 
-pbxProject.prototype.parseSync = function () {
+pbxProject.prototype.parseSync = function() {
     var file_contents = fs.readFileSync(this.filepath, 'utf-8');
 
     this.hash = parser.parse(file_contents);
     return this;
 }
 
-pbxProject.prototype.writeSync = function () {
+pbxProject.prototype.writeSync = function() {
     this.writer = new pbxWriter(this.hash);
     return this.writer.writeSync();
 }
 
-pbxProject.prototype.allUuids = function () {
+pbxProject.prototype.allUuids = function() {
     var sections = this.hash.project.objects,
         uuids = [],
         section;
@@ -61,18 +61,18 @@ pbxProject.prototype.allUuids = function () {
         uuids = uuids.concat(Object.keys(section))
     }
 
-    uuids = uuids.filter(function (str) {
+    uuids = uuids.filter(function(str) {
         return !COMMENT_KEY.test(str) && str.length == 24;
     });
 
     return uuids;
 }
 
-pbxProject.prototype.generateUuid = function () {
+pbxProject.prototype.generateUuid = function() {
     var id = uuid.v4()
-                .replace(/-/g,'')
-                .substr(0,24)
-                .toUpperCase()
+        .replace(/-/g, '')
+        .substr(0, 24)
+        .toUpperCase()
 
     if (this.allUuids().indexOf(id) >= 0) {
         return this.generateUuid();
@@ -81,7 +81,7 @@ pbxProject.prototype.generateUuid = function () {
     }
 }
 
-pbxProject.prototype.addPluginFile = function (path, opt) {
+pbxProject.prototype.addPluginFile = function(path, opt) {
     var file = new pbxFile(path, opt);
 
     file.plugin = true; // durr
@@ -98,7 +98,7 @@ pbxProject.prototype.addPluginFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.removePluginFile = function (path, opt) {
+pbxProject.prototype.removePluginFile = function(path, opt) {
     var file = new pbxFile(path, opt);
     correctForPluginsPath(file, this);
 
@@ -108,9 +108,29 @@ pbxProject.prototype.removePluginFile = function (path, opt) {
     return file;
 }
 
+pbxProject.prototype.addProductFile = function(targetPath, opt) {
+    var file = new pbxFile(targetPath, opt);
 
-pbxProject.prototype.addSourceFile = function (path, opt) {
-  
+    file.includeInIndex = 0;
+    file.fileRef = this.generateUuid();
+
+    this.addToPbxFileReferenceSection(file);         // PBXFileReference
+    this.addToProductsPbxGroup(file);                // PBXGroup
+
+    return file;
+}
+
+pbxProject.prototype.removeProductFile = function(path, opt) {
+    var file = new pbxFile(path, opt);
+
+    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromProductsPbxGroup(file);           // PBXGroup
+
+    return file;
+}
+
+pbxProject.prototype.addSourceFile = function(path, opt) {
+
     var file = this.addPluginFile(path, opt);
     if (!file) return false;
 
@@ -124,7 +144,7 @@ pbxProject.prototype.addSourceFile = function (path, opt) {
 }
 
 
-pbxProject.prototype.removeSourceFile = function (path, opt) {
+pbxProject.prototype.removeSourceFile = function(path, opt) {
     var file = this.removePluginFile(path, opt)
     file.target = opt ? opt.target : undefined;
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
@@ -133,15 +153,15 @@ pbxProject.prototype.removeSourceFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.addHeaderFile = function (path, opt) {
+pbxProject.prototype.addHeaderFile = function(path, opt) {
     return this.addPluginFile(path, opt)
 }
 
-pbxProject.prototype.removeHeaderFile = function (path, opt) {
+pbxProject.prototype.removeHeaderFile = function(path, opt) {
     return this.removePluginFile(path, opt)
 }
 
-pbxProject.prototype.addResourceFile = function (path, opt) {
+pbxProject.prototype.addResourceFile = function(path, opt) {
     opt = opt || {};
 
     var file;
@@ -173,27 +193,27 @@ pbxProject.prototype.addResourceFile = function (path, opt) {
     return file;
 }
 
-pbxProject.prototype.removeResourceFile = function (path, opt) {
+pbxProject.prototype.removeResourceFile = function(path, opt) {
     var file = new pbxFile(path, opt);
     file.target = opt ? opt.target : undefined;
-    
+
     correctForResourcesPath(file, this);
 
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromResourcesPbxGroup(file);          // PBXGroup
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-    
+
     return file;
 }
 
-pbxProject.prototype.addFramework = function (fpath, opt) {
+pbxProject.prototype.addFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     // catch duplicates
     if (this.hasFile(file.path)) return false;
 
     file.uuid = this.generateUuid();
-    file.fileRef = this.generateUuid();    
+    file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
 
@@ -201,15 +221,15 @@ pbxProject.prototype.addFramework = function (fpath, opt) {
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
     this.addToFrameworksPbxGroup(file);         // PBXGroup
     this.addToPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
-    
-    if(opt && opt.customFramework == true) {
-      this.addToFrameworkSearchPaths(file);
+
+    if (opt && opt.customFramework == true) {
+        this.addToFrameworkSearchPaths(file);
     }
 
     return file;
 }
 
-pbxProject.prototype.removeFramework = function (fpath, opt) {
+pbxProject.prototype.removeFramework = function(fpath, opt) {
     var file = new pbxFile(fpath, opt);
     file.target = opt ? opt.target : undefined;
 
@@ -217,15 +237,15 @@ pbxProject.prototype.removeFramework = function (fpath, opt) {
     this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
     this.removeFromFrameworksPbxGroup(file);         // PBXGroup
     this.removeFromPbxFrameworksBuildPhase(file);    // PBXFrameworksBuildPhase
-    
-    if(opt && opt.customFramework) {
-      this.removeFromFrameworkSearchPaths(path.dirname(fpath));
+
+    if (opt && opt.customFramework) {
+        this.removeFromFrameworkSearchPaths(path.dirname(fpath));
     }
 
     return file;
 }
 
-pbxProject.prototype.addStaticLibrary = function (path, opt) {
+pbxProject.prototype.addStaticLibrary = function(path, opt) {
     opt = opt || {};
 
     var file;
@@ -254,18 +274,18 @@ pbxProject.prototype.addStaticLibrary = function (path, opt) {
 }
 
 // helper addition functions
-pbxProject.prototype.addToPbxBuildFileSection = function (file) {
+pbxProject.prototype.addToPbxBuildFileSection = function(file) {
     var commentKey = f("%s_comment", file.uuid);
 
     this.pbxBuildFileSection()[file.uuid] = pbxBuildFileObj(file);
     this.pbxBuildFileSection()[commentKey] = pbxBuildFileComment(file);
 }
 
-pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
+pbxProject.prototype.removeFromPbxBuildFileSection = function(file) {
     var uuid;
 
-    for(uuid in this.pbxBuildFileSection()) {
-        if(this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
+    for (uuid in this.pbxBuildFileSection()) {
+        if (this.pbxBuildFileSection()[uuid].fileRef_comment == file.basename) {
             file.uuid = uuid;
             delete this.pbxBuildFileSection()[uuid];
         }
@@ -274,7 +294,7 @@ pbxProject.prototype.removeFromPbxBuildFileSection = function (file) {
     delete this.pbxBuildFileSection()[commentKey];
 }
 
-pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceTree) {
+pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTree) {
     var groups = this.hash.project.objects['PBXGroup'],
         pbxGroupUuid = this.generateUuid(),
         commentKey = f("%s_comment", pbxGroupUuid),
@@ -287,15 +307,15 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         },
         fileReferenceSection = this.pbxFileReferenceSection(),
         filePathToReference = {};
-        
+
     for (var key in fileReferenceSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-        
+
         var fileReferenceKey = key.split(COMMENT_KEY)[0],
             fileReference = fileReferenceSection[fileReferenceKey];
-        
-        filePathToReference[fileReference.path] = {fileRef: fileReferenceKey, basename: fileReferenceSection[key]};
+
+        filePathToReference[fileReference.path] = { fileRef: fileReferenceKey, basename: fileReferenceSection[key] };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
@@ -308,7 +328,7 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
             pbxGroup.children.push(pbxGroupChild(filePathToReference[filePathQuoted]));
             continue;
         }
-        
+
         var file = new pbxFile(filePath);
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
@@ -316,149 +336,167 @@ pbxProject.prototype.addPbxGroup = function (filePathsArray, name, path, sourceT
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
         pbxGroup.children.push(pbxGroupChild(file));
     }
-    
+
     if (groups) {
         groups[pbxGroupUuid] = pbxGroup;
         groups[commentKey] = name;
     }
-    
-    return {uuid: pbxGroupUuid, pbxGroup: pbxGroup};
+
+    return { uuid: pbxGroupUuid, pbxGroup: pbxGroup };
 }
 
-pbxProject.prototype.addToPbxFileReferenceSection = function (file) {
+pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 
     this.pbxFileReferenceSection()[file.fileRef] = pbxFileReferenceObj(file);
     this.pbxFileReferenceSection()[commentKey] = pbxFileReferenceComment(file);
 }
 
-pbxProject.prototype.removeFromPbxFileReferenceSection = function (file) {
+pbxProject.prototype.removeFromPbxFileReferenceSection = function(file) {
 
     var i;
     var refObj = pbxFileReferenceObj(file);
-    for(i in this.pbxFileReferenceSection()) {
-        if(this.pbxFileReferenceSection()[i].name == refObj.name ||
-           ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
-           this.pbxFileReferenceSection()[i].path == refObj.path ||
-           ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
+    for (i in this.pbxFileReferenceSection()) {
+        if (this.pbxFileReferenceSection()[i].name == refObj.name ||
+            ('"' + this.pbxFileReferenceSection()[i].name + '"') == refObj.name ||
+            this.pbxFileReferenceSection()[i].path == refObj.path ||
+            ('"' + this.pbxFileReferenceSection()[i].path + '"') == refObj.path) {
             file.fileRef = file.uuid = i;
             delete this.pbxFileReferenceSection()[i];
             break;
         }
     }
     var commentKey = f("%s_comment", file.fileRef);
-    if(this.pbxFileReferenceSection()[commentKey] != undefined) {
+    if (this.pbxFileReferenceSection()[commentKey] != undefined) {
         delete this.pbxFileReferenceSection()[commentKey];
     }
 
     return file;
 }
 
-pbxProject.prototype.addToPluginsPbxGroup = function (file) {
+pbxProject.prototype.addToPluginsPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Plugins');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromPluginsPbxGroup = function (file) {
+pbxProject.prototype.removeFromPluginsPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Plugins').children, i;
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToResourcesPbxGroup = function (file) {
+pbxProject.prototype.addToResourcesPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Resources');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromResourcesPbxGroup = function (file) {
+pbxProject.prototype.removeFromResourcesPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Resources').children, i;
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToFrameworksPbxGroup = function (file) {
+pbxProject.prototype.addToFrameworksPbxGroup = function(file) {
     var pluginsGroup = this.pbxGroupByName('Frameworks');
     pluginsGroup.children.push(pbxGroupChild(file));
 }
 
-pbxProject.prototype.removeFromFrameworksPbxGroup = function (file) {
+pbxProject.prototype.removeFromFrameworksPbxGroup = function(file) {
     var pluginsGroupChildren = this.pbxGroupByName('Frameworks').children;
-    
-    for(i in pluginsGroupChildren) {
-        if(pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
-           pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
+
+    for (i in pluginsGroupChildren) {
+        if (pbxGroupChild(file).value == pluginsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == pluginsGroupChildren[i].comment) {
             pluginsGroupChildren.splice(i, 1);
             break;
         }
     }
 }
-pbxProject.prototype.addToPbxSourcesBuildPhase = function (file) {
+
+
+pbxProject.prototype.addToProductsPbxGroup = function(file) {
+    var productsGroup = this.pbxGroupByName('Products');
+    productsGroup.children.push(pbxGroupChild(file));
+}
+
+pbxProject.prototype.removeFromProductsPbxGroup = function(file) {
+    var productsGroupChildren = this.pbxGroupByName('Products').children, i;
+    for (i in productsGroupChildren) {
+        if (pbxGroupChild(file).value == productsGroupChildren[i].value &&
+            pbxGroupChild(file).comment == productsGroupChildren[i].comment) {
+            productsGroupChildren.splice(i, 1);
+            break;
+        }
+    }
+}
+
+pbxProject.prototype.addToPbxSourcesBuildPhase = function(file) {
     var sources = this.pbxSourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxSourcesBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxSourcesBuildPhase = function(file) {
 
     var sources = this.pbxSourcesBuildPhaseObj(file.target), i;
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
-            break; 
+            break;
         }
     }
 }
 
-pbxProject.prototype.addToPbxResourcesBuildPhase = function (file) {
+pbxProject.prototype.addToPbxResourcesBuildPhase = function(file) {
     var sources = this.pbxResourcesBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxResourcesBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxResourcesBuildPhase = function(file) {
     var sources = this.pbxResourcesBuildPhaseObj(file.target), i;
 
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addToPbxFrameworksBuildPhase = function (file) {
+pbxProject.prototype.addToPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
     sources.files.push(pbxBuildPhaseObj(file));
 }
 
-pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function (file) {
+pbxProject.prototype.removeFromPbxFrameworksBuildPhase = function(file) {
     var sources = this.pbxFrameworksBuildPhaseObj(file.target);
-    for(i in sources.files) {
-        if(sources.files[i].comment == longComment(file)) {
+    for (i in sources.files) {
+        if (sources.files[i].comment == longComment(file)) {
             sources.files.splice(i, 1);
             break;
         }
     }
 }
 
-pbxProject.prototype.addXCConfigurationList = function (configurationObjectsArray, defaultConfigurationName, comment) {
+pbxProject.prototype.addXCConfigurationList = function(configurationObjectsArray, defaultConfigurationName, comment) {
     var pbxBuildConfigurationSection = this.pbxXCBuildConfigurationSection(),
-        pbxXCConfigurationListSection = this.pbxXCConfigurationList(), 
+        pbxXCConfigurationListSection = this.pbxXCConfigurationList(),
         xcConfigurationListUuid = this.generateUuid(),
         commentKey = f("%s_comment", xcConfigurationListUuid),
-        xcConfigurationList = { 
+        xcConfigurationList = {
             isa: 'XCConfigurationList',
             buildConfigurations: [],
             defaultConfigurationIsVisible: 0,
-            defaultConfigurationName: defaultConfigurationName 
+            defaultConfigurationName: defaultConfigurationName
         };
 
     for (var index = 0; index < configurationObjectsArray.length; index++) {
@@ -468,18 +506,18 @@ pbxProject.prototype.addXCConfigurationList = function (configurationObjectsArra
 
         pbxBuildConfigurationSection[configurationUuid] = configuration;
         pbxBuildConfigurationSection[configurationCommentKey] = configuration.name;
-        xcConfigurationList.buildConfigurations.push({value: configurationUuid, comment: configuration.name});
+        xcConfigurationList.buildConfigurations.push({ value: configurationUuid, comment: configuration.name });
     }
-    
+
     if (pbxXCConfigurationListSection) {
         pbxXCConfigurationListSection[xcConfigurationListUuid] = xcConfigurationList;
         pbxXCConfigurationListSection[commentKey] = comment;
     }
-    
-    return {uuid: xcConfigurationListUuid, xcConfigurationList: xcConfigurationList};
+
+    return { uuid: xcConfigurationListUuid, xcConfigurationList: xcConfigurationList };
 }
 
-pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) {
+pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     if (!target)
         return undefined;
 
@@ -487,13 +525,13 @@ pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) 
 
     if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);
-        
+
     for (var index = 0; index < dependencyTargets.length; index++) {
         var dependencyTarget = dependencyTargets[index];
         if (typeof nativeTargets[dependencyTarget] == "undefined")
             throw new Error("Invalid target: " + dependencyTarget);
-    }
-    
+        }
+
     var pbxTargetDependency = 'PBXTargetDependency',
         pbxContainerItemProxy = 'PBXContainerItemProxy',
         pbxTargetDependencySection = this.hash.project.objects[pbxTargetDependency],
@@ -506,32 +544,32 @@ pbxProject.prototype.addTargetDependency = function (target, dependencyTargets) 
             targetDependencyCommentKey = f("%s_comment", targetDependencyUuid),
             itemProxyUuid = this.generateUuid(),
             itemProxyCommentKey = f("%s_comment", itemProxyUuid),
-            itemProxy =  {
+            itemProxy = {
                 isa: pbxContainerItemProxy,
                 containerPortal: this.hash.project['rootObject'],
                 containerPortal_comment: this.hash.project['rootObject_comment'],
                 proxyType: 1,
                 remoteGlobalIDString: dependencyTargetUuid,
-                remoteInfo: nativeTargets[dependencyTargetUuid].name 
+                remoteInfo: nativeTargets[dependencyTargetUuid].name
             },
             targetDependency = {
                 isa: pbxTargetDependency,
-                target: dependencyTargetUuid, 
+                target: dependencyTargetUuid,
                 target_comment: nativeTargets[dependencyTargetCommentKey],
                 targetProxy: itemProxyUuid,
                 targetProxy_comment: pbxContainerItemProxy
             };
-            
+
         if (pbxContainerItemProxySection && pbxTargetDependencySection) {
             pbxContainerItemProxySection[itemProxyUuid] = itemProxy;
             pbxContainerItemProxySection[itemProxyCommentKey] = pbxContainerItemProxy;
             pbxTargetDependencySection[targetDependencyUuid] = targetDependency;
             pbxTargetDependencySection[targetDependencyCommentKey] = pbxTargetDependency;
-            nativeTargets[target].dependencies.push({value: targetDependencyUuid, comment: pbxTargetDependency})
+            nativeTargets[target].dependencies.push({ value: targetDependencyUuid, comment: pbxTargetDependency })
         }
     }
-    
-    return {uuid: target, target: nativeTargets[target]};
+
+    return { uuid: target, target: nativeTargets[target] };
 }
 
 pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
@@ -547,20 +585,20 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
             runOnlyForDeploymentPostprocessing: 0
         },
         filePathToBuildFile = {};
-    
+
     for (var key in buildFileSection) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-        
+
         var buildFileKey = key.split(COMMENT_KEY)[0],
             buildFile = buildFileSection[buildFileKey];
-            fileReference = fileReferenceSection[buildFile.fileRef];
+        fileReference = fileReferenceSection[buildFile.fileRef];
 
         if (!fileReference) continue;
 
         var pbxFileObj = new pbxFile(fileReference.path);
-        
-        filePathToBuildFile[fileReference.path] = {uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group};
+
+        filePathToBuildFile[fileReference.path] = { uuid: buildFileKey, basename: pbxFileObj.basename, group: pbxFileObj.group };
     }
 
     for (var index = 0; index < filePathsArray.length; index++) {
@@ -575,35 +613,35 @@ pbxProject.prototype.addBuildPhase = function (filePathsArray, isa, comment) {
             buildPhase.files.push(pbxBuildPhaseObj(filePathToBuildFile[filePathQuoted]));
             continue;
         }
-        
+
         file.uuid = this.generateUuid();
         file.fileRef = this.generateUuid();
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         this.addToPbxBuildFileSection(file);        // PBXBuildFile
         buildPhase.files.push(pbxBuildPhaseObj(file));
     }
-    
+
     if (section) {
         section[buildPhaseUuid] = buildPhase;
         section[commentKey] = comment;
     }
-    
-    return {uuid: buildPhaseUuid, buildPhase: buildPhase};
+
+    return { uuid: buildPhaseUuid, buildPhase: buildPhase };
 }
 
 // helper access functions
-pbxProject.prototype.pbxProjectSection = function () {
+pbxProject.prototype.pbxProjectSection = function() {
     return this.hash.project.objects['PBXProject'];
 }
-pbxProject.prototype.pbxBuildFileSection = function () {
+pbxProject.prototype.pbxBuildFileSection = function() {
     return this.hash.project.objects['PBXBuildFile'];
 }
 
-pbxProject.prototype.pbxXCBuildConfigurationSection = function () {
+pbxProject.prototype.pbxXCBuildConfigurationSection = function() {
     return this.hash.project.objects['XCBuildConfiguration'];
 }
 
-pbxProject.prototype.pbxFileReferenceSection = function () {
+pbxProject.prototype.pbxFileReferenceSection = function() {
     return this.hash.project.objects['PBXFileReference'];
 }
 
@@ -611,19 +649,19 @@ pbxProject.prototype.pbxNativeTarget = function () {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
-pbxProject.prototype.pbxXCConfigurationList = function () {
+pbxProject.prototype.pbxXCConfigurationList = function() {
     return this.hash.project.objects['XCConfigurationList'];
 }
 
-pbxProject.prototype.pbxGroupByName = function (name) {
-    return this.pbxItemByComment(name, 'PBXGroup');    
+pbxProject.prototype.pbxGroupByName = function(name) {
+    return this.pbxItemByComment(name, 'PBXGroup');
 }
 
-pbxProject.prototype.pbxTargetByName = function (name) {
+pbxProject.prototype.pbxTargetByName = function(name) {
     return this.pbxItemByComment(name, 'PBXNativeTarget');
 }
 
-pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
+pbxProject.prototype.pbxItemByComment = function(name, pbxSectionName) {
     var section = this.hash.project.objects[pbxSectionName],
         key, itemKey;
 
@@ -640,56 +678,56 @@ pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
     return null;
 }
 
-pbxProject.prototype.pbxSourcesBuildPhaseObj = function (target) {
+pbxProject.prototype.pbxSourcesBuildPhaseObj = function(target) {
     return this.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', target);
 }
 
-pbxProject.prototype.pbxResourcesBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources',target);
+pbxProject.prototype.pbxResourcesBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', target);
 }
 
-pbxProject.prototype.pbxFrameworksBuildPhaseObj = function (target) {
-    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks',target);
+pbxProject.prototype.pbxFrameworksBuildPhaseObj = function(target) {
+    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
 }
 
 // Find Build Phase from group/target
-pbxProject.prototype.buildPhase = function (group,target) {
+pbxProject.prototype.buildPhase = function(group, target) {
 
     if (!target)
         return undefined;
 
      var nativeTargets = this.pbxNativeTarget();
      if (typeof nativeTargets[target] == "undefined")
-        throw new Error("Invalid target: "+target);
+        throw new Error("Invalid target: " + target);
 
-     var nativeTarget= nativeTargets[target];
-     var buildPhases = nativeTarget.buildPhases;
+    var nativeTarget = nativeTargets[target];
+    var buildPhases = nativeTarget.buildPhases;
      for(var i in buildPhases)
      {
         var buildPhase = buildPhases[i];
         if (buildPhase.comment==group)
-            return buildPhase.value+"_comment";
-     } 
-}
+            return buildPhase.value + "_comment";
+        }
+    }
 
-pbxProject.prototype.buildPhaseObject = function (name, group,target) {
+pbxProject.prototype.buildPhaseObject = function(name, group, target) {
     var section = this.hash.project.objects[name],
         obj, sectionKey, key;
-    var buildPhase = this.buildPhase(group,target);
+    var buildPhase = this.buildPhase(group, target);
 
     for (key in section) {
 
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
-  
+
         // select the proper buildPhase
         if (buildPhase && buildPhase!=key)
             continue;
         if (section[key] == group) {
-            sectionKey = key.split(COMMENT_KEY)[0];  
+            sectionKey = key.split(COMMENT_KEY)[0];
             return section[sectionKey];
         }
-     }
+    }
     return null;
 }
 
@@ -703,7 +741,7 @@ pbxProject.prototype.updateProductName = function(name) {
     this.updateBuildProperty('PRODUCT_NAME', '"' + name + '"');
 }
 
-pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
+pbxProject.prototype.removeFromFrameworkSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'FRAMEWORK_SEARCH_PATHS',
@@ -731,7 +769,7 @@ pbxProject.prototype.removeFromFrameworkSearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
+pbxProject.prototype.addToFrameworkSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -743,7 +781,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
             continue;
 
         if (!buildSettings['FRAMEWORK_SEARCH_PATHS']
-                || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['FRAMEWORK_SEARCH_PATHS'] === INHERITED) {
             buildSettings['FRAMEWORK_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -751,7 +789,7 @@ pbxProject.prototype.addToFrameworkSearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
+pbxProject.prototype.removeFromLibrarySearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'LIBRARY_SEARCH_PATHS',
@@ -779,7 +817,7 @@ pbxProject.prototype.removeFromLibrarySearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.addToLibrarySearchPaths = function (file) {
+pbxProject.prototype.addToLibrarySearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -791,7 +829,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
             continue;
 
         if (!buildSettings['LIBRARY_SEARCH_PATHS']
-                || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
+            || buildSettings['LIBRARY_SEARCH_PATHS'] === INHERITED) {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
@@ -803,7 +841,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
     }
 }
 
-pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
+pbxProject.prototype.removeFromHeaderSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
@@ -828,7 +866,7 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
 
     }
 }
-pbxProject.prototype.addToHeaderSearchPaths = function (file) {
+pbxProject.prototype.addToHeaderSearchPaths = function(file) {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         INHERITED = '"$(inherited)"',
         config, buildSettings, searchPaths;
@@ -851,7 +889,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
     }
 }
 // a JS getter. hmmm
-pbxProject.prototype.__defineGetter__("productName", function () {
+pbxProject.prototype.__defineGetter__("productName", function() {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
         config, productName;
 
@@ -865,7 +903,7 @@ pbxProject.prototype.__defineGetter__("productName", function () {
 });
 
 // check if file is present
-pbxProject.prototype.hasFile = function (filePath) {
+pbxProject.prototype.hasFile = function(filePath) {
     var files = nonComments(this.pbxFileReferenceSection()),
         file, id;
     for (id in files) {
@@ -909,18 +947,18 @@ function pbxFileReferenceObj(file) {
 
     obj.isa = 'PBXFileReference';
     obj.lastKnownFileType = file.lastType;
-    
+
     obj.name = "\"" + file.basename + "\"";
-    obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
-    
+        obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
+
     obj.sourceTree = file.sourceTree;
 
     if (file.fileEncoding)
         obj.fileEncoding = file.fileEncoding;
-        
+
     if (file.explicitFileType)
         obj.explicitFileType = file.explicitFileType;
-        
+
     if ('includeInIndex' in file)
         obj.includeInIndex = file.includeInIndex;
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -591,7 +591,7 @@ pbxProject.prototype.addTargetDependency = function(target, dependencyTargets) {
     if (!target)
         return undefined;
 
-    var nativeTargets = this.pbxNativeTarget();
+    var nativeTargets = this.pbxNativeTargetSection();
 
     if (typeof nativeTargets[target] == "undefined")
         throw new Error("Invalid target: " + target);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -345,6 +345,16 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
     return { uuid: pbxGroupUuid, pbxGroup: pbxGroup };
 }
 
+pbxProject.prototype.addToPbxProjectSection = function(target) {
+
+    var newTarget = {
+            value: target.pbxNativeTarget,
+            comment: pbxNativeTargetComment(target.pbxNativeTarget)
+        };
+
+    this.pbxProjectSection()[this.getFirstProject()['uuid']]['targets'].push(newTarget);
+}
+
 pbxProject.prototype.addToPbxFileReferenceSection = function(file) {
     var commentKey = f("%s_comment", file.fileRef);
 
@@ -989,6 +999,10 @@ function pbxBuildFileComment(file) {
 
 function pbxFileReferenceComment(file) {
     return file.basename;
+}
+
+function pbxNativeTargetComment(target) {
+    return target.name;
 }
 
 function longComment(file) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -401,7 +401,7 @@ pbxProject.prototype.addPbxGroup = function(filePathsArray, name, path, sourceTr
 pbxProject.prototype.addToPbxProjectSection = function(target) {
 
     var newTarget = {
-            value: target.pbxNativeTarget,
+            value: target.uuid,
             comment: pbxNativeTargetComment(target.pbxNativeTarget)
         };
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -896,6 +896,30 @@ pbxProject.prototype.removeFromOtherLinkerFlags = function (flag) {
     }
 }
 
+pbxProject.prototype.addToBuildSettings = function (buildSetting, value) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        config, buildSettings;
+
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
+        
+        buildSettings[buildSetting] = value;
+    }
+}
+
+pbxProject.prototype.removeFromBuildSettings = function (buildSetting) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        config, buildSettings;
+
+    for (config in configurations) {
+        buildSettings = configurations[config].buildSettings;
+        
+        if (buildSettings[buildSetting]) {
+            delete buildSettings[buildSetting];
+        }
+    }
+}
+
 // a JS getter. hmmm
 pbxProject.prototype.__defineGetter__("productName", function () {
     var configurations = nonComments(this.pbxXCBuildConfigurationSection()),

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1165,6 +1165,24 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+function producttypeForTargettype (targetType) {
+
+    PRODUCTTYPE_BY_TARGETTYPE = {
+            application: 'com.apple.product-type.application',
+            app_extension: 'com.apple.product-type.app-extension',
+            bundle: 'com.apple.product-type.bundle',
+            command_line_tool: 'com.apple.product-type.tool',
+            dynamic_library: 'com.apple.product-type.library.dynamic',
+            framework: 'com.apple.product-type.framework',
+            static_library: 'com.apple.product-type.library.static',
+            unit_test_bundle: 'com.apple.product-type.bundle.unit-test',
+            watch_app: 'com.apple.product-type.application.watchapp',
+            watch_extension: 'com.apple.product-type.watchkit-extension'
+        };
+
+    return PRODUCTTYPE_BY_TARGETTYPE[targetType]
+}
+
 pbxProject.prototype.getFirstProject = function() {
 
     // Get pbxProject container

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -823,6 +823,31 @@ pbxProject.prototype.buildPhaseObject = function(name, group, target) {
     return null;
 }
 
+pbxProject.prototype.addBuildProperty = function(prop, value, build_name) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        key, configuration;
+
+    for (key in configurations){
+        configuration = configurations[key];
+        if (!build_name || configuration.name === build_name){
+            configuration.buildSettings[prop] = value;
+        }
+    }
+}
+
+pbxProject.prototype.removeBuildProperty = function(prop, build_name) {
+    var configurations = nonComments(this.pbxXCBuildConfigurationSection()),
+        key, configuration;
+
+    for (key in configurations){
+        configuration = configurations[key];
+        console.error(configuration);
+        if (configuration.buildSettings[prop] &&
+            !build_name || configuration.name === build_name){
+            delete configuration.buildSettings[prop];
+        }
+    }
+}
 
 pbxProject.prototype.updateBuildProperty = function(prop, value) {
     var config = this.pbxXCBuildConfigurationSection();

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -218,6 +218,7 @@ pbxProject.prototype.addFramework = function(fpath, opt) {
     file.fileRef = this.generateUuid();
     file.target = opt ? opt.target : undefined;
 
+    if (this.hasFile(file.path)) return false;
 
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxFileReferenceSection(file);    // PBXFileReference
@@ -1012,15 +1013,24 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
     // Setup uuid and name of new target
     var targetUuid = this.generateUuid(),
         targetType = type,
-        targetSubfolder = subfolder,
+        targetSubfolder = subfolder || name,
         targetName = name.trim();
+        
+    // Check type against list of allowed target types
+    if (!targetName) {
+        throw new Error("Target name missing.");
+    }    
+
+    // Check type against list of allowed target types
+    if (!targetType) {
+        throw new Error("Target type missing.");
+    } 
 
     // Check type against list of allowed target types
     if (!producttypeForTargettype(targetType)) {
-        console.error ('Invalid target type: ' + targetType);
-        return false
+        throw new Error("Target type invalid: " + targetType);
     }
-
+    
     // Build Configuration: Create
     var buildConfigurationsList = [
         {
@@ -1131,31 +1141,18 @@ function pbxBuildFileObj(file) {
 }
 
 function pbxFileReferenceObj(file) {
-    var obj = Object.create(null);
+    var fileObject = {
+        isa: "PBXFileReference",
+        name: "\"" + file.basename + "\"",
+        path: "\"" + file.path.replace(/\\/g, '/') + "\"",
+        sourceTree: file.sourceTree,
+        fileEncoding: file.fileEncoding,
+        lastKnownFileType: file.lastKnownFileType,
+        explicitFileType: file.explicitFileType,
+        includeInIndex: file.includeInIndex
+    };
 
-    obj.isa = 'PBXFileReference';
-
-    obj.name = "\"" + file.basename + "\"";
-
-    if (file.path) {
-        obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
-    }
-
-    obj.sourceTree = file.sourceTree;
-
-    if (file.fileEncoding)
-        obj.fileEncoding = file.fileEncoding;
-
-    if (file.lastKnownFileType)
-        obj.lastKnownFileType = file.lastKnownFileType;
-
-    if (file.explicitFileType)
-        obj.explicitFileType = file.explicitFileType;
-
-    if (file.includeInIndex)
-        obj.includeInIndex = file.includeInIndex;
-
-    return obj;
+    return fileObject;
 }
 
 function pbxGroupChild(file) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -933,6 +933,93 @@ pbxProject.prototype.hasFile = function(filePath) {
     return false;
 }
 
+pbxProject.prototype.addTarget = function(name, type) {
+
+    // Setup uuid and name of new target
+    var targetUuid = this.generateUuid(),
+        targetType = type,
+        targetName = name.trim();
+
+    // Check type against list of allowed target types
+    if (!producttypeForTargettype(targetType)) {
+        console.error ('Invalid target type: ' + targetType);
+        return false
+    }
+
+    // Build Configuration: Create
+    var buildConfigurationsList = [
+        {
+            name: 'Debug',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
+                INFOPLIST_FILE: targetName + '-Info.Plist',
+                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                PRODUCT_NAME: targetName,
+                SKIP_INSTALL: 'YES'
+            }
+        },
+        {
+            name: 'Release',
+            isa: 'XCBuildConfiguration',
+            buildSettings: {
+                INFOPLIST_FILE: targetName + '-Info.Plist',
+                LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+                PRODUCT_NAME: targetName,
+                SKIP_INSTALL: 'YES'
+            }
+        }
+    ];
+
+    // Build Configuration: Add
+    var buildConfigurations = this.addXCConfigurationList(buildConfigurationsList, 'Release', 'Build configuration list for PBXNativeTarget "' + targetName +'"'),
+        buildConfigurationsUuid = buildConfigurations.uuid;
+
+    // Product: Create
+    var productName = targetName,
+        productType = producttypeForTargettype(targetType),
+        productFile = this.addProductFile(productName, { 'explicitFileType': productType }),
+        productFileName = productFile.basename;
+
+    // Product: Embed in first target (only for "extension"-type targets)
+    if (targetType === 'app_extension') {
+        var embedPhase;
+        var embedFile;
+
+        // TODO: Add embedding via "PBXCopyFilesBuildPhase" build phase
+    };
+
+    // Target: Create
+    var target = {
+            uuid: targetUuid,
+            pbxNativeTarget: {
+                isa: 'PBXNativeTarget',
+                name: targetName,
+                productName: targetName,
+                productReference: productFile.fileRef,
+                productType: '"' + producttypeForTargettype(targetType) + '"',
+                buildConfigurationList: buildConfigurationsUuid,
+                buildPhases: [],
+                buildRules: [],
+                dependencies: []
+            }
+    };
+
+    // Target: Add to PBXNativeTarget section
+    this.addToPbxNativeTargetSection(target)
+
+    // Target: Add uuid to root project
+    this.addToPbxProjectSection(target);
+
+    // Target: Add dependency for this target to first (main) target
+    this.addTargetDependency(this.getFirstTarget().uuid, [target.uuid]);
+
+
+    // Return target on success
+    return target;
+
+};
+
 // helper recursive prop search+replace
 function propReplace(obj, prop, value) {
     var o = {};

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -903,7 +903,6 @@ pbxProject.prototype.removeBuildProperty = function(prop, build_name) {
 
     for (key in configurations){
         configuration = configurations[key];
-        console.error(configuration);
         if (configuration.buildSettings[prop] &&
             !build_name || configuration.name === build_name){
             delete configuration.buildSettings[prop];

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -304,7 +304,7 @@ pbxProject.prototype.removeFramework = function(fpath, opt) {
     this.removeFromPbxEmbedFrameworksBuildPhase(file); // PBXCopyFilesBuildPhase
 
     if (opt && opt.customFramework) {
-        this.removeFromFrameworkSearchPaths(path.dirname(fpath));
+        this.removeFromFrameworkSearchPaths(file.dirname);
     }
 
     return file;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -132,9 +132,22 @@ pbxProject.prototype.removeProductFile = function(path, opt) {
     return file;
 }
 
-pbxProject.prototype.addSourceFile = function(path, opt) {
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.addSourceFile = function (path, opt, group) {
+    var file;
+    if (group) {
+        file = this.addFile(path, group, opt);
+    }
+    else {
+        file = this.addPluginFile(path, opt);
+    }
 
-    var file = this.addPluginFile(path, opt);
     if (!file) return false;
 
     file.target = opt ? opt.target : undefined;
@@ -146,9 +159,21 @@ pbxProject.prototype.addSourceFile = function(path, opt) {
     return file;
 }
 
-
-pbxProject.prototype.removeSourceFile = function(path, opt) {
-    var file = this.removePluginFile(path, opt)
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.removeSourceFile = function (path, opt, group) {
+    var file;
+    if (group) {
+        file = this.removeFile(path, group, opt);
+    }
+    else {
+        file = this.removePluginFile(path, opt);
+    }
     file.target = opt ? opt.target : undefined;
     this.removeFromPbxBuildFileSection(file);        // PBXBuildFile
     this.removeFromPbxSourcesBuildPhase(file);       // PBXSourcesBuildPhase
@@ -156,12 +181,36 @@ pbxProject.prototype.removeSourceFile = function(path, opt) {
     return file;
 }
 
-pbxProject.prototype.addHeaderFile = function(path, opt) {
-    return this.addPluginFile(path, opt)
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.addHeaderFile = function (path, opt, group) {
+    if (group) {
+        return this.addFile(path, group, opt);
+    }
+    else {
+        return this.addPluginFile(path, opt);
+    }
 }
 
-pbxProject.prototype.removeHeaderFile = function(path, opt) {
-    return this.removePluginFile(path, opt)
+/**
+ *
+ * @param path {String}
+ * @param opt {Object} see pbxFile for avail options
+ * @param group {String} group key
+ * @returns {Object} file; see pbxFile
+ */
+pbxProject.prototype.removeHeaderFile = function (path, opt, group) {
+    if (group) {
+        return this.removeFile(path, group, opt);
+    }
+    else {
+        return this.removePluginFile(path, opt);
+    }
 }
 
 pbxProject.prototype.addResourceFile = function(path, opt) {
@@ -746,7 +795,20 @@ pbxProject.prototype.pbxXCConfigurationList = function() {
 }
 
 pbxProject.prototype.pbxGroupByName = function(name) {
-    return this.pbxItemByComment(name, 'PBXGroup');
+    var groups = this.hash.project.objects['PBXGroup'],
+        key, groupKey;
+
+    for (key in groups) {
+        // only look for comments
+        if (!COMMENT_KEY.test(key)) continue;
+
+        if (groups[key] == name) {
+            groupKey = key.split(COMMENT_KEY)[0];
+            return groups[groupKey];
+        }
+    }
+
+    return null;
 }
 
 pbxProject.prototype.pbxTargetByName = function(name) {
@@ -824,9 +886,22 @@ pbxProject.prototype.buildPhaseObject = function(name, group, target) {
 }
 
 
-pbxProject.prototype.updateBuildProperty = function(prop, value) {
-    var config = this.pbxXCBuildConfigurationSection();
-    propReplace(config, prop, value);
+/**
+ *
+ * @param prop {String}
+ * @param value {String|Array|Object|Number|Boolean}
+ * @param build {String} Release or Debug
+ */
+pbxProject.prototype.updateBuildProperty = function(prop, value, build) {
+    var configs = this.pbxXCBuildConfigurationSection();
+    for (var configName in configs) {
+        if (!COMMENT_KEY.test(configName)) {
+            var config = configs[configName];
+            if ( (build && config.name === build) || (!build) ) {
+                config.buildSettings[prop] = value;
+            }
+        }
+    }
 }
 
 pbxProject.prototype.updateProductName = function(name) {
@@ -1363,5 +1438,162 @@ pbxProject.prototype.getFirstTarget = function() {
         firstTarget: firstTarget
     }
 }
+
+/*** NEW ***/
+
+pbxProject.prototype.addToPbxGroup = function (file, groupKey) {
+    var group = this.getPBXGroupByKey(groupKey);
+    if (group && group.children !== undefined) {
+        if (typeof file === 'string') {
+            //Group Key
+            var childGroup = {
+                value:file,
+                comment: this.getPBXGroupByKey(file).name
+            };
+
+            group.children.push(childGroup);
+        }
+        else {
+            //File Object
+            group.children.push(pbxGroupChild(file));
+        }
+    }
+}
+
+pbxProject.prototype.removeFromPbxGroup = function (file, groupKey) {
+    var group = this.getPBXGroupByKey(groupKey);
+    if (group) {
+        var groupChildren = group.children, i;
+        for(i in groupChildren) {
+            if(pbxGroupChild(file).value == groupChildren[i].value &&
+                pbxGroupChild(file).comment == groupChildren[i].comment) {
+                groupChildren.splice(i, 1);
+                break;
+            }
+        }
+    }
+}
+
+pbxProject.prototype.getPBXGroupByKey = function(key) {
+    return this.hash.project.objects['PBXGroup'][key];
+};
+
+pbxProject.prototype.findPBXGroupKey = function(criteria) {
+    var groups = this.hash.project.objects['PBXGroup'];
+    var target;
+
+    for (var key in groups) {
+        // only look for comments
+        if (COMMENT_KEY.test(key)) continue;
+
+        var group = groups[key];
+        if (criteria && criteria.path && criteria.name) {
+            if (criteria.path === group.path && criteria.name === group.name) {
+                target = key;
+                break
+            }
+        }
+        else if (criteria && criteria.path) {
+            if (criteria.path === group.path) {
+                target = key;
+                break
+            }
+        }
+        else if (criteria && criteria.name) {
+            if (criteria.name === group.name) {
+                target = key;
+                break
+            }
+        }
+    }
+
+    return target;
+}
+
+pbxProject.prototype.pbxCreateGroup = function(name, pathName) {
+
+    //Create object
+    var model = {
+        isa:"PBXGroup",
+        children: [],
+        name: name,
+        path: pathName,
+        sourceTree: '"<group>"'
+    };
+    var key = this.generateUuid();
+
+    //Create comment
+    var commendId = key + '_comment';
+
+    //add obj and commentObj to groups;
+    var groups = this.hash.project.objects['PBXGroup'];
+    groups[commendId] = name;
+    groups[key] = model;
+
+    return key;
+}
+
+
+pbxProject.prototype.getPBXObject = function(name) {
+    return this.hash.project.objects[name];
+}
+
+
+
+pbxProject.prototype.addFile = function (path, group, opt) {
+    var file = new pbxFile(path, opt);
+
+    // null is better for early errors
+    if (this.hasFile(file.path)) return null;
+
+    file.fileRef = this.generateUuid();
+
+    this.addToPbxFileReferenceSection(file);    // PBXFileReference
+    this.addToPbxGroup(file, group);            // PBXGroup
+
+    return file;
+}
+
+pbxProject.prototype.removeFile = function (path, group, opt) {
+    var file = new pbxFile(path, opt);
+
+    this.removeFromPbxFileReferenceSection(file);    // PBXFileReference
+    this.removeFromPbxGroup(file, group);            // PBXGroup
+
+    return file;
+}
+
+
+
+pbxProject.prototype.getBuildProperty = function(prop, build) {
+    var target;
+    var configs = this.pbxXCBuildConfigurationSection();
+    for (var configName in configs) {
+        if (!COMMENT_KEY.test(configName)) {
+            var config = configs[configName];
+            if ( (build && config.name === build) || (build === undefined) ) {
+                if (config.buildSettings[prop] !== undefined) {
+                    target = config.buildSettings[prop];
+                }
+            }
+        }
+    }
+    return target;
+}
+
+pbxProject.prototype.getBuildConfigByName = function(name) {
+    var target = {};
+    var configs = this.pbxXCBuildConfigurationSection();
+    for (var configName in configs) {
+        if (!COMMENT_KEY.test(configName)) {
+            var config = configs[configName];
+            if (config.name === name)  {
+                target[configName] = config;
+            }
+        }
+    }
+    return target;
+}
+
 
 module.exports = pbxProject;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -973,10 +973,13 @@ function pbxFileReferenceObj(file) {
     if (file.fileEncoding)
         obj.fileEncoding = file.fileEncoding;
 
+    if (file.lastKnownFileType)
+        obj.lastKnownFileType = file.lastKnownFileType;
+
     if (file.explicitFileType)
         obj.explicitFileType = file.explicitFileType;
 
-    if ('includeInIndex' in file)
+    if (file.includeInIndex)
         obj.includeInIndex = file.includeInIndex;
 
     return obj;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1057,18 +1057,8 @@ pbxProject.prototype.addTarget = function(name, type) {
     var productName = targetName,
         productType = producttypeForTargettype(targetType),
         productFileType = filetypeForProducttype(productType),
-        productFile = this.addProductFile(productName, { 'target': targetUuid, 'group': 'CopyFiles' }),
+        productFile = this.addProductFile(productName, { 'target': targetUuid,  'explicitFileType': productFileType}),
         productFileName = productFile.basename;
-
-    // Product: Embed (only for "extension"-type targets)
-    if (targetType === 'app_extension') {
-
-        // Create "Copy Files" build phase for target which contains the extension
-        this.addBuildPhase([], 'PBXCopyFilesBuildPhase', 'CopyFiles', this.getFirstTarget().uuid)
-
-        // Add product reference to "Copy Files" build phase
-        this.addCopyfile(productFileName, { 'explicitFileType': productFileType, 'target': this.getFirstTarget().uuid })
-    };
 
     // Target: Create
     var target = {
@@ -1088,6 +1078,14 @@ pbxProject.prototype.addTarget = function(name, type) {
 
     // Target: Add to PBXNativeTarget section
     this.addToPbxNativeTargetSection(target)
+
+    // Product: Embed (only for "extension"-type targets)
+    if (targetType === 'app_extension') {
+        // Create "Copy Files" build phase for target which contains the extension
+        this.addToPbxBuildFileSection(productFile);
+        var newPhase = this.addBuildPhase([productFileName], 'PBXCopyFilesBuildPhase', 'Copy Files', targetType)
+        this.addBuildPhaseToTarget(newPhase.buildPhase, this.getFirstTarget().uuid)
+    };
 
     // Target: Add uuid to root project
     this.addToPbxProjectSection(target);

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1095,7 +1095,7 @@ function pbxBuildFileComment(file) {
 }
 
 function pbxFileReferenceComment(file) {
-    return file.basename;
+    return path.basename(file.path);
 }
 
 function pbxNativeTargetComment(target) {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1053,7 +1053,10 @@ function pbxFileReferenceObj(file) {
     obj.lastKnownFileType = file.lastType;
 
     obj.name = "\"" + file.basename + "\"";
+
+    if (file.path) {
         obj.path = "\"" + file.path.replace(/\\/g, '/') + "\"";
+    }
 
     obj.sourceTree = file.sourceTree;
 

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1282,6 +1282,19 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+
+function buildPhaseNameForIsa (isa) {
+
+    BUILDPHASENAME_BY_ISA = {
+        PBXCopyFilesBuildPhase: 'Copy Files',
+        PBXResourcesBuildPhase: 'Resources',
+        PBXSourcesBuildPhase: 'Sources',
+        PBXFrameworksBuildPhase: 'Frameworks'
+    }
+
+    return BUILDPHASENAME_BY_ISA[isa]
+}
+
 function producttypeForTargettype (targetType) {
 
     PRODUCTTYPE_BY_TARGETTYPE = {

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -1016,4 +1016,35 @@ function unquote(str) {
     if (str) return str.replace(/^"(.*)"$/, "$1");
 }
 
+pbxProject.prototype.getFirstProject = function() {
+
+    // Get pbxProject container
+    var pbxProjectContainer = this.pbxProjectSection();
+
+    // Get first pbxProject UUID
+    var firstProjectUuid = Object.keys(pbxProjectContainer)[0];
+
+    // Get first pbxProject
+    var firstProject = pbxProjectContainer[firstProjectUuid];
+
+     return {
+        uuid: firstProjectUuid,
+        firstProject: firstProject
+    }
+}
+
+pbxProject.prototype.getFirstTarget = function() {
+
+    // Get first targets UUID
+    var firstTargetUuid = this.getFirstProject()['firstProject']['targets'][0].value;
+
+    // Get first pbxNativeTarget
+    var firstTarget = this.pbxNativeTargetSection()[firstTargetUuid];
+
+    return {
+        uuid: firstTargetUuid,
+        firstTarget: firstTarget
+    }
+}
+
 module.exports = pbxProject;

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -520,6 +520,7 @@ pbxProject.prototype.addToXcVersionGroupSection = function(file) {
             isa: 'XCVersionGroup',
             children: file.models.map(function (el) { return el.fileRef; }),
             currentVersion: file.currentModel.fileRef,
+            name: path.basename(file.path),
             path: file.path,
             sourceTree: '"<group>"',
             versionGroupType: 'wrapper.xcdatamodel'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   },
   "scripts": {
     "test": "node_modules/.bin/nodeunit test/parser test"
-  }
+  }, 
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=0.6.7"
   },
   "dependencies": {
-    "node-uuid":"1.3.3",
+    "node-uuid":"1.4.7",
     "pegjs":"0.6.2",
     "simple-plist": "0.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
   "version": "0.8.2",
-  "main":"index.js",
+  "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"
   },
@@ -11,8 +11,9 @@
     "node": ">=0.6.7"
   },
   "dependencies": {
+    "node-uuid":"1.3.3",
     "pegjs":"0.6.2",
-    "node-uuid":"1.3.3"
+    "simple-plist": "0.0.4"
   },
   "devDependencies": {
     "nodeunit":"0.9.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main":"index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {
     "node-uuid":"1.4.7",
-    "pegjs":"0.6.2",
-    "simple-plist": "0.0.4"
+    "pegjs": "0.9.0",
+    "simple-plist": "0.1.4"
   },
   "devDependencies": {
-    "nodeunit":"0.9.0"
+    "nodeunit": "0.9.1"
   },
   "scripts": {
     "test": "node_modules/.bin/nodeunit test/parser test"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.3",
+  "version": "0.8.6",
   "main": "index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Andrew Lunny <alunny@gmail.com>",
   "name": "xcode",
   "description": "parser for xcodeproj/project.pbxproj files",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main":"index.js",
   "repository": {
     "url": "https://github.com/alunny/node-xcode.git"

--- a/test/BuildSettings.js
+++ b/test/BuildSettings.js
@@ -1,0 +1,41 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+var PRODUCT_NAME = '"KitchenSinktablet"';
+
+exports.addAndRemoveToFromBuildSettings = {
+    'add should add the build setting to each configuration section':function(test) {
+        var buildSetting = 'some/buildSetting';
+        var value = 'some/buildSetting';
+        proj.addToBuildSettings(buildSetting, value);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            test.ok(config[ref].buildSettings[buildSetting] === value);
+        }
+        test.done();
+    },
+    'remove should remove from the build settings in each configuration section':function(test) {
+        var buildSetting = 'some/buildSetting';
+        proj.addToBuildSettings(buildSetting, 'some/buildSetting');
+        proj.removeFromBuildSettings(buildSetting);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            test.ok(!config[ref].buildSettings.hasOwnProperty(buildSetting));
+        }
+        test.done();
+    }
+}

--- a/test/OtherLinkerFlags.js
+++ b/test/OtherLinkerFlags.js
@@ -1,0 +1,43 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+var PRODUCT_NAME = '"KitchenSinktablet"';
+
+exports.addAndRemoveToFromOtherLinkerFlags = {
+    'add should add the flag to each configuration section':function(test) {
+        var flag = 'some/flag';
+        proj.addToOtherLinkerFlags(flag);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            var lib = config[ref].buildSettings.OTHER_LDFLAGS;
+            test.ok(lib[1].indexOf(flag) > -1);
+        }
+        test.done();
+    },
+    'remove should remove from the path to each configuration section':function(test) {
+        var flag = 'some/flag';
+        proj.addToOtherLinkerFlags(flag);
+        proj.removeFromOtherLinkerFlags(flag);
+        var config = proj.pbxXCBuildConfigurationSection();
+        for (var ref in config) {
+            if (ref.indexOf('_comment') > -1 || config[ref].buildSettings.PRODUCT_NAME != PRODUCT_NAME) continue;
+            var lib = config[ref].buildSettings.OTHER_LDFLAGS;
+            test.ok(lib.length === 1);
+            test.ok(lib[0].indexOf(flag) == -1);
+        }
+        test.done();
+    }
+}

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -106,7 +106,7 @@ exports.addBuildPhase = {
         test.done();
     },
     'should set target to Frameworks given \'frameworks\' as target': function (test) {
-        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid,  'frameworks').buildPhase;
+        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid, 'frameworks').buildPhase;
         test.equal(buildPhase.dstSubfolderSpec, 10);
         test.done();
     },

--- a/test/addBuildPhase.js
+++ b/test/addBuildPhase.js
@@ -104,5 +104,10 @@ exports.addBuildPhase = {
         
         test.deepEqual(initialFileReferenceSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 2);
         test.done();
-    }
+    },
+    'should set target to Frameworks given \'frameworks\' as target': function (test) {
+        var buildPhase = proj.addBuildPhase(['file.m'], 'PBXCopyFilesBuildPhase', 'Copy Files', proj.getFirstTarget().uuid,  'frameworks').buildPhase;
+        test.equal(buildPhase.dstSubfolderSpec, 10);
+        test.done();
+    },
 }

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -128,7 +128,7 @@ exports.addFramework = {
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
         test.equal(buildFileEntry.fileRef_comment, 'libsqlite3.dylib');
         test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'Weak' ] });
-        
+
         test.done();
     },
     'should add to the Frameworks PBXGroup': function (test) {
@@ -153,6 +153,13 @@ exports.addFramework = {
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
+        test.done();
+    },
+    'should not add to the PBXFrameworksBuildPhase': function (test) {
+        var newFile = proj.addFramework('Private.framework', {link: false}),
+            frameworks = proj.pbxFrameworksBuildPhaseObj();
+
+        test.equal(frameworks.files.length, 15);
         test.done();
     },
     'should have the right values for the Sources entry': function (test) {
@@ -188,12 +195,26 @@ exports.addFramework = {
         // should add path to framework search path
         var frameworkPaths = frameworkSearchPaths(proj);
             expectedPath = '"\\"/path/to\\""';
-        
+
         for (i = 0; i < frameworkPaths.length; i++) {
             var current = frameworkPaths[i];
             test.ok(current.indexOf('"$(inherited)"') >= 0);
             test.ok(current.indexOf(expectedPath) >= 0);
         }
         test.done();
-    }
+    },
+    'should add to the Embed Frameworks PBXCopyFilesBuildPhase': function (test) {
+        var newFile = proj.addFramework('/path/to/SomeEmbeddableCustom.framework', {customFramework: true, embed: true}),
+            frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
+
+        test.equal(frameworks.files.length, 1);
+        test.done();
+    },
+    'should not add to the Embed Frameworks PBXCopyFilesBuildPhase by default': function (test) {
+        var newFile = proj.addFramework('/path/to/Custom.framework', {customFramework: true}),
+            frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
+
+        test.equal(frameworks.files.length, 0);
+        test.done();
+    },
 }

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -219,6 +219,9 @@ exports.addFramework = {
         var newFile = proj.addFramework('/path/to/SomeEmbeddableCustom.framework', {customFramework: true, embed: true}),
             frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
+        var buildPhaseInPbx = proj.pbxEmbedFrameworksBuildPhaseObj();
+        test.equal(buildPhaseInPbx.dstSubfolderSpec, 10);
+
         test.equal(frameworks.files.length, 1);
         test.done();
     },

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -131,6 +131,18 @@ exports.addFramework = {
 
         test.done();
     },
+    'should add the PBXBuildFile object correctly /w signable frameworks': function (test) {
+        var newFile = proj.addFramework('libsqlite3.dylib', { sign: true }),
+            buildFileSection = proj.pbxBuildFileSection(),
+            buildFileEntry = buildFileSection[newFile.uuid];
+
+        test.equal(buildFileEntry.isa, 'PBXBuildFile');
+        test.equal(buildFileEntry.fileRef, newFile.fileRef);
+        test.equal(buildFileEntry.fileRef_comment, 'libsqlite3.dylib');
+        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'CodeSignOnCopy' ] });
+
+        test.done();
+    },
     'should add to the Frameworks PBXGroup': function (test) {
         var newLength = proj.pbxGroupByName('Frameworks').children.length + 1,
             newFile = proj.addFramework('libsqlite3.dylib'),

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -81,7 +81,7 @@ exports.addFramework = {
             fileRefEntry = fileRefSection[newFile.fileRef];
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
-        test.equal(fileRefEntry.lastKnownFileType, '"compiled.mach-o.dylib"');
+        test.equal(fileRefEntry.lastKnownFileType, 'compiled.mach-o.dylib');
         test.equal(fileRefEntry.name, '"libsqlite3.dylib"');
         test.equal(fileRefEntry.path, '"usr/lib/libsqlite3.dylib"');
         test.equal(fileRefEntry.sourceTree, 'SDKROOT');

--- a/test/addFramework.js
+++ b/test/addFramework.js
@@ -45,7 +45,6 @@ function frameworkSearchPaths(proj) {
 exports.addFramework = {
     'should return a pbxFile': function (test) {
         var newFile = proj.addFramework('libsqlite3.dylib');
-        console.log(newFile);
 
         test.equal(newFile.constructor, pbxFile);
         test.done()
@@ -128,18 +127,6 @@ exports.addFramework = {
         test.equal(buildFileEntry.fileRef, newFile.fileRef);
         test.equal(buildFileEntry.fileRef_comment, 'libsqlite3.dylib');
         test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'Weak' ] });
-
-        test.done();
-    },
-    'should add the PBXBuildFile object correctly /w signable frameworks': function (test) {
-        var newFile = proj.addFramework('libsqlite3.dylib', { sign: true }),
-            buildFileSection = proj.pbxBuildFileSection(),
-            buildFileEntry = buildFileSection[newFile.uuid];
-
-        test.equal(buildFileEntry.isa, 'PBXBuildFile');
-        test.equal(buildFileEntry.fileRef, newFile.fileRef);
-        test.equal(buildFileEntry.fileRef_comment, 'libsqlite3.dylib');
-        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'CodeSignOnCopy' ] });
 
         test.done();
     },
@@ -227,6 +214,19 @@ exports.addFramework = {
             frameworks = proj.pbxEmbedFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 0);
+        test.done();
+    },
+    'should add the PBXBuildFile object correctly /w signable frameworks': function (test) {
+        var newFile = proj.addFramework('/path/to/SomeSignable.framework', { customFramework: true, embed: true, sign: true }),
+            buildFileSection = proj.pbxBuildFileSection(),
+            buildFileEntry = buildFileSection[newFile.uuid];
+
+        test.equal(newFile.group, 'Embed Frameworks');
+        test.equal(buildFileEntry.isa, 'PBXBuildFile');
+        test.equal(buildFileEntry.fileRef, newFile.fileRef);
+        test.equal(buildFileEntry.fileRef_comment, 'SomeSignable.framework');
+        test.deepEqual(buildFileEntry.settings, { ATTRIBUTES: [ 'CodeSignOnCopy' ] });
+
         test.done();
     },
 }

--- a/test/addRemovePbxGroup.js
+++ b/test/addRemovePbxGroup.js
@@ -12,7 +12,7 @@ exports.setUp = function (callback) {
     callback();
 }
 
-exports.addPbxGroup = {
+exports.addRemovePbxGroup = {
     'should return a pbxGroup': function (test) {
         var pbxGroup = proj.addPbxGroup(['file.m'], 'MyGroup', 'Application', 'Application', '"<group>"');
         
@@ -145,5 +145,16 @@ exports.addPbxGroup = {
         // for each file added in the file reference section two keyes are added - one for the object and one for the comment
         test.equal(initialBuildFileSectionItemsCount.length, afterAdditionBuildFileSectionItemsCount.length - 4);
         test.done();
+    },
+    'should remove a pbxGroup': function (test) {
+        var groupName = 'MyGroup';
+        proj.addPbxGroup(['file.m'], groupName, 'Application', 'Application', '"<group>"');
+        proj.removePbxGroup(groupName);
+        
+        var pbxGroupInPbx = proj.pbxGroupByName(groupName);
+        console.log(pbxGroupInPbx);
+        
+        test.ok(!pbxGroupInPbx);
+        test.done()
     }
 }

--- a/test/addResourceFile.js
+++ b/test/addResourceFile.js
@@ -90,7 +90,7 @@ exports.addResourceFile = {
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
-        test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+        test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
         test.equal(fileRefEntry.name, '"assets.bundle"');
         test.equal(fileRefEntry.path, '"Resources/assets.bundle"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');
@@ -151,7 +151,7 @@ exports.addResourceFile = {
                             
             test.equal(fileRefEntry.isa, 'PBXFileReference');
             test.equal(fileRefEntry.fileEncoding, undefined);
-            test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+            test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
             test.equal(fileRefEntry.name, '"assets.bundle"');
             test.equal(fileRefEntry.path, '"Plugins/assets.bundle"');
             test.equal(fileRefEntry.sourceTree, '"<group>"');

--- a/test/addTarget.js
+++ b/test/addTarget.js
@@ -1,0 +1,89 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+var TARGET_NAME = 'TestExtension',
+    TARGET_TYPE = 'app_extension',
+    TARGET_SUBFOLDER_NAME = 'TestExtensionFiles';
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.addTarget = {
+    'should throw when target name is missing': function (test) {
+        test.throws(function() {
+            proj.addTarget(null, TARGET_TYPE);
+        });
+        
+        test.done();
+    },
+    'should throw when target type missing': function (test) {
+        test.throws(function() {
+            proj.addTarget(TARGET_NAME, null);
+        });
+        
+        test.done();
+    },
+    'should create a new target': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME);
+        
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+                
+        test.done();
+    },
+    'should create a new target and add source, framework, resource and header files and the corresponding build phases': function (test) {
+        var target = proj.addTarget(TARGET_NAME, TARGET_TYPE, TARGET_SUBFOLDER_NAME),
+            options = { 'target' : target.uuid };
+   
+        var sourceFile = proj.addSourceFile('Plugins/file.m', options),
+            sourcePhase = proj.addBuildPhase([], 'PBXSourcesBuildPhase', 'Sources', target.uuid),
+            resourceFile = proj.addResourceFile('assets.bundle', options),
+            resourcePhase = proj.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', target.uuid),
+            frameworkFile = proj.addFramework('libsqlite3.dylib', options);
+            frameworkPhase = proj.addBuildPhase([], 'PBXFrameworkBuildPhase', 'Frameworks', target.uuid),
+            headerFile = proj.addHeaderFile('file.h', options);
+        
+        test.ok(sourcePhase);
+        test.ok(resourcePhase);
+        test.ok(frameworkPhase);
+          
+        test.equal(sourceFile.constructor, pbxFile);
+        test.equal(resourceFile.constructor, pbxFile);
+        test.equal(frameworkFile.constructor, pbxFile);
+        test.equal(headerFile.constructor, pbxFile);
+        
+        test.ok(typeof target == 'object');
+        test.ok(target.uuid);
+        test.ok(target.pbxNativeTarget);
+        test.ok(target.pbxNativeTarget.isa);
+        test.ok(target.pbxNativeTarget.name);
+        test.ok(target.pbxNativeTarget.productName);
+        test.ok(target.pbxNativeTarget.productReference);
+        test.ok(target.pbxNativeTarget.productType);
+        test.ok(target.pbxNativeTarget.buildConfigurationList);
+        test.ok(target.pbxNativeTarget.buildPhases);
+        test.ok(target.pbxNativeTarget.buildRules);
+        test.ok(target.pbxNativeTarget.dependencies);
+    
+        test.done();
+        
+    }   
+}

--- a/test/addTargetDependency.js
+++ b/test/addTargetDependency.js
@@ -40,7 +40,7 @@ exports.addTargetDependency = {
         test.done();
     },
     'should add targetDependencies to target': function (test) {
-        var targetInPbxProj = proj.pbxNativeTarget()['1D6058900D05DD3D006BFB55'];
+        var targetInPbxProj = proj.pbxNativeTargetSection()['1D6058900D05DD3D006BFB55'];
         test.deepEqual(targetInPbxProj.dependencies, []);
         
         var target = proj.addTargetDependency('1D6058900D05DD3D006BFB55', ['1D6058900D05DD3D006BFB54', '1D6058900D05DD3D006BFB55']).target;

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -152,7 +152,8 @@ exports.dataModelDocument = {
         test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
         test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
         test.equal(xcVersionGroupEntry.name, path.basename(singleDataModelFilePath));
-        test.equal(xcVersionGroupEntry.path, singleDataModelFilePath);
+        // Need to validate against normalized path, since paths should contain forward slash on OSX
+        test.equal(xcVersionGroupEntry.path, singleDataModelFilePath.replace(/\\/g, '/'));
         test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
         test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');
 

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -151,6 +151,7 @@ exports.dataModelDocument = {
         test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
         test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
         test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
+        test.equal(xcVersionGroupEntry.name, path.basename(singleDataModelFilePath));
         test.equal(xcVersionGroupEntry.path, singleDataModelFilePath);
         test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
         test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');

--- a/test/dataModelDocument.js
+++ b/test/dataModelDocument.js
@@ -1,0 +1,160 @@
+var jsonProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(jsonProject),
+    path = require('path'),
+    pbx = require('../lib/pbxProject'),
+    pbxFile = require('../lib/pbxFile'),
+    proj = new pbx('.'),
+    singleDataModelFilePath = __dirname + '/fixtures/single-data-model.xcdatamodeld',
+    multipleDataModelFilePath = __dirname + '/fixtures/multiple-data-model.xcdatamodeld';
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.dataModelDocument = {
+    'should return a pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.equal(newFile.constructor, pbxFile);
+        test.done()
+    },
+    'should set a uuid on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.ok(newFile.uuid);
+        test.done()
+    },
+    'should set a fileRef on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+
+        test.ok(newFile.fileRef);
+        test.done()
+    },
+    'should set an optional target on the pbxFile': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath, undefined, { target: target }),
+            target = proj.findTargetKey('TestApp');
+
+        test.equal(newFile.target, target);
+        test.done()
+    },
+    'should populate the PBXBuildFile section with 2 fields': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            buildFileSection = proj.pbxBuildFileSection(),
+            bfsLength = Object.keys(buildFileSection).length;
+
+        test.equal(59 + 1, bfsLength);
+        test.ok(buildFileSection[newFile.uuid]);
+        test.ok(buildFileSection[newFile.uuid + '_comment']);
+
+        test.done();
+    },
+    'should populate the PBXFileReference section with 2 fields for single model document': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            fileRefSection = proj.pbxFileReferenceSection(),
+            frsLength = Object.keys(fileRefSection).length;
+
+        test.equal(66 + 2, frsLength);
+        test.ok(fileRefSection[newFile.models[0].fileRef]);
+        test.ok(fileRefSection[newFile.models[0].fileRef + '_comment']);
+
+        test.done();
+    },
+    'should populate the PBXFileReference section with 2 fields for each model of a model document': function (test) {
+        var newFile = proj.addDataModelDocument(multipleDataModelFilePath),
+            fileRefSection = proj.pbxFileReferenceSection(),
+            frsLength = Object.keys(fileRefSection).length;
+
+        test.equal(66 + 2 * 2, frsLength);
+        test.ok(fileRefSection[newFile.models[0].fileRef]);
+        test.ok(fileRefSection[newFile.models[0].fileRef + '_comment']);
+        test.ok(fileRefSection[newFile.models[1].fileRef]);
+        test.ok(fileRefSection[newFile.models[1].fileRef + '_comment']);
+
+        test.done();
+    },
+    'should add to resources group by default': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath);
+            groupChildren = proj.pbxGroupByName('Resources').children,
+            found = false;
+
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === 'single-data-model.xcdatamodeld') {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to group specified by key': function (test) {
+        var group = 'Frameworks',
+            newFile = proj.addDataModelDocument(singleDataModelFilePath, proj.findPBXGroupKey({ name: group }));
+            groupChildren = proj.pbxGroupByName(group).children;
+
+        var found = false;
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to group specified by name': function (test) {
+        var group = 'Frameworks',
+            newFile = proj.addDataModelDocument(singleDataModelFilePath, group);
+            groupChildren = proj.pbxGroupByName(group).children;
+
+        var found = false;
+        for (var index in groupChildren) {
+            if (groupChildren[index].comment === path.basename(singleDataModelFilePath)) {
+                found = true;
+                break;
+            }
+        }
+        test.ok(found);
+        test.done();
+    },
+    'should add to the PBXSourcesBuildPhase': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            sources = proj.pbxSourcesBuildPhaseObj();
+
+        test.equal(sources.files.length, 2 + 1);
+        test.done();
+    },
+    'should create a XCVersionGroup section': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection();
+
+        test.ok(xcVersionGroupSection[newFile.fileRef]);
+        test.done();
+    },
+    'should populate the XCVersionGroup comment correctly': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection(),
+            commentKey = newFile.fileRef + '_comment';
+
+        test.equal(xcVersionGroupSection[commentKey], path.basename(singleDataModelFilePath));
+        test.done();
+    },
+    'should add the XCVersionGroup object correctly': function (test) {
+        var newFile = proj.addDataModelDocument(singleDataModelFilePath),
+            xcVersionGroupSection = proj.xcVersionGroupSection(),
+            xcVersionGroupEntry = xcVersionGroupSection[newFile.fileRef];
+
+        test.equal(xcVersionGroupEntry.isa, 'XCVersionGroup');
+        test.equal(xcVersionGroupEntry.children[0], newFile.models[0].fileRef);
+        test.equal(xcVersionGroupEntry.currentVersion, newFile.currentModel.fileRef);
+        test.equal(xcVersionGroupEntry.path, singleDataModelFilePath);
+        test.equal(xcVersionGroupEntry.sourceTree, '"<group>"');
+        test.equal(xcVersionGroupEntry.versionGroupType, 'wrapper.xcdatamodel');
+
+        test.done();
+    }
+}

--- a/test/fixtures/full-project.json
+++ b/test/fixtures/full-project.json
@@ -1,1 +1,1252 @@
-{"project":{"archiveVersion":1,"classes":{},"objectVersion":45,"objects":{"PBXBuildFile":{"1D3623260D0F684500981E51":{"isa":"PBXBuildFile","fileRef":"1D3623250D0F684500981E51","fileRef_comment":"AppDelegate.m"},"1D3623260D0F684500981E51_comment":"AppDelegate.m in Sources","1D60589B0D05DD56006BFB54":{"isa":"PBXBuildFile","fileRef":"29B97316FDCFA39411CA2CEA","fileRef_comment":"main.m"},"1D60589B0D05DD56006BFB54_comment":"main.m in Sources","1D60589F0D05DD5A006BFB54":{"isa":"PBXBuildFile","fileRef":"1D30AB110D05D00D00671497","fileRef_comment":"Foundation.framework"},"1D60589F0D05DD5A006BFB54_comment":"Foundation.framework in Frameworks","1DF5F4E00D08C38300B7A737":{"isa":"PBXBuildFile","fileRef":"1DF5F4DF0D08C38300B7A737","fileRef_comment":"UIKit.framework","settings":{"ATTRIBUTES":["Weak"]}},"1DF5F4E00D08C38300B7A737_comment":"UIKit.framework in Frameworks","1F766FE113BBADB100FB74C0":{"isa":"PBXBuildFile","fileRef":"1F766FDC13BBADB100FB74C0","fileRef_comment":"Localizable.strings"},"1F766FE113BBADB100FB74C0_comment":"Localizable.strings in Resources","1F766FE213BBADB100FB74C0":{"isa":"PBXBuildFile","fileRef":"1F766FDF13BBADB100FB74C0","fileRef_comment":"Localizable.strings"},"1F766FE213BBADB100FB74C0_comment":"Localizable.strings in Resources","288765FD0DF74451002DB57D":{"isa":"PBXBuildFile","fileRef":"288765FC0DF74451002DB57D","fileRef_comment":"CoreGraphics.framework"},"288765FD0DF74451002DB57D_comment":"CoreGraphics.framework in Frameworks","301BF552109A68D80062928A":{"isa":"PBXBuildFile","fileRef":"301BF535109A57CC0062928A","fileRef_comment":"libPhoneGap.a"},"301BF552109A68D80062928A_comment":"libPhoneGap.a in Frameworks","301BF570109A69640062928A":{"isa":"PBXBuildFile","fileRef":"301BF56E109A69640062928A","fileRef_comment":"www"},"301BF570109A69640062928A_comment":"www in Resources","301BF5B5109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5B4109A6A2B0062928A","fileRef_comment":"AddressBook.framework"},"301BF5B5109A6A2B0062928A_comment":"AddressBook.framework in Frameworks","301BF5B7109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5B6109A6A2B0062928A","fileRef_comment":"AddressBookUI.framework"},"301BF5B7109A6A2B0062928A_comment":"AddressBookUI.framework in Frameworks","301BF5B9109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5B8109A6A2B0062928A","fileRef_comment":"AudioToolbox.framework"},"301BF5B9109A6A2B0062928A_comment":"AudioToolbox.framework in Frameworks","301BF5BB109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5BA109A6A2B0062928A","fileRef_comment":"AVFoundation.framework","settings":{"ATTRIBUTES":["Weak"]}},"301BF5BB109A6A2B0062928A_comment":"AVFoundation.framework in Frameworks","301BF5BD109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5BC109A6A2B0062928A","fileRef_comment":"CFNetwork.framework"},"301BF5BD109A6A2B0062928A_comment":"CFNetwork.framework in Frameworks","301BF5BF109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5BE109A6A2B0062928A","fileRef_comment":"CoreLocation.framework"},"301BF5BF109A6A2B0062928A_comment":"CoreLocation.framework in Frameworks","301BF5C1109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5C0109A6A2B0062928A","fileRef_comment":"MediaPlayer.framework"},"301BF5C1109A6A2B0062928A_comment":"MediaPlayer.framework in Frameworks","301BF5C3109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5C2109A6A2B0062928A","fileRef_comment":"QuartzCore.framework"},"301BF5C3109A6A2B0062928A_comment":"QuartzCore.framework in Frameworks","301BF5C5109A6A2B0062928A":{"isa":"PBXBuildFile","fileRef":"301BF5C4109A6A2B0062928A","fileRef_comment":"SystemConfiguration.framework"},"301BF5C5109A6A2B0062928A_comment":"SystemConfiguration.framework in Frameworks","3053AC6F109B7857006FCFE7":{"isa":"PBXBuildFile","fileRef":"3053AC6E109B7857006FCFE7","fileRef_comment":"VERSION"},"3053AC6F109B7857006FCFE7_comment":"VERSION in Resources","305D5FD1115AB8F900A74A75":{"isa":"PBXBuildFile","fileRef":"305D5FD0115AB8F900A74A75","fileRef_comment":"MobileCoreServices.framework"},"305D5FD1115AB8F900A74A75_comment":"MobileCoreServices.framework in Frameworks","3072F99713A8081B00425683":{"isa":"PBXBuildFile","fileRef":"3072F99613A8081B00425683","fileRef_comment":"Capture.bundle"},"3072F99713A8081B00425683_comment":"Capture.bundle in Resources","307D28A2123043360040C0FA":{"isa":"PBXBuildFile","fileRef":"307D28A1123043350040C0FA","fileRef_comment":"PhoneGapBuildSettings.xcconfig"},"307D28A2123043360040C0FA_comment":"PhoneGapBuildSettings.xcconfig in Resources","308D05371370CCF300D202BF":{"isa":"PBXBuildFile","fileRef":"308D052E1370CCF300D202BF","fileRef_comment":"icon-72.png"},"308D05371370CCF300D202BF_comment":"icon-72.png in Resources","308D05381370CCF300D202BF":{"isa":"PBXBuildFile","fileRef":"308D052F1370CCF300D202BF","fileRef_comment":"icon.png"},"308D05381370CCF300D202BF_comment":"icon.png in Resources","308D05391370CCF300D202BF":{"isa":"PBXBuildFile","fileRef":"308D05301370CCF300D202BF","fileRef_comment":"icon@2x.png"},"308D05391370CCF300D202BF_comment":"icon@2x.png in Resources","308D053C1370CCF300D202BF":{"isa":"PBXBuildFile","fileRef":"308D05341370CCF300D202BF","fileRef_comment":"Default.png"},"308D053C1370CCF300D202BF_comment":"Default.png in Resources","308D053D1370CCF300D202BF":{"isa":"PBXBuildFile","fileRef":"308D05351370CCF300D202BF","fileRef_comment":"Default@2x.png"},"308D053D1370CCF300D202BF_comment":"Default@2x.png in Resources","30E1352710E2C1420031B30D":{"isa":"PBXBuildFile","fileRef":"30E1352610E2C1420031B30D","fileRef_comment":"PhoneGap.plist"},"30E1352710E2C1420031B30D_comment":"PhoneGap.plist in Resources","30E5649213A7FCAF007403D8":{"isa":"PBXBuildFile","fileRef":"30E5649113A7FCAF007403D8","fileRef_comment":"CoreMedia.framework","settings":{"ATTRIBUTES":["Weak"]}},"30E5649213A7FCAF007403D8_comment":"CoreMedia.framework in Frameworks"},"PBXContainerItemProxy":{"301BF534109A57CC0062928A":{"isa":"PBXContainerItemProxy","containerPortal":"301BF52D109A57CC0062928A","containerPortal_comment":"PhoneGapLib.xcodeproj","proxyType":2,"remoteGlobalIDString":"D2AAC07E0554694100DB518D","remoteInfo":"PhoneGapLib"},"301BF534109A57CC0062928A_comment":"PBXContainerItemProxy","301BF550109A68C00062928A":{"isa":"PBXContainerItemProxy","containerPortal":"301BF52D109A57CC0062928A","containerPortal_comment":"PhoneGapLib.xcodeproj","proxyType":1,"remoteGlobalIDString":"D2AAC07D0554694100DB518D","remoteInfo":"PhoneGapLib"},"301BF550109A68C00062928A_comment":"PBXContainerItemProxy","30E47BC2136F595F00DBB853":{"isa":"PBXContainerItemProxy","containerPortal":"301BF52D109A57CC0062928A","containerPortal_comment":"PhoneGapLib.xcodeproj","proxyType":2,"remoteGlobalIDString":"303258D8136B2C9400982B63","remoteInfo":"PhoneGap"},"30E47BC2136F595F00DBB853_comment":"PBXContainerItemProxy"},"PBXFileReference":{"1D30AB110D05D00D00671497":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"Foundation.framework","path":"System/Library/Frameworks/Foundation.framework","sourceTree":"SDKROOT"},"1D30AB110D05D00D00671497_comment":"Foundation.framework","1D3623240D0F684500981E51":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"sourcecode.c.h","path":"AppDelegate.h","sourceTree":"\"<group>\""},"1D3623240D0F684500981E51_comment":"AppDelegate.h","1D3623250D0F684500981E51":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"sourcecode.c.objc","path":"AppDelegate.m","sourceTree":"\"<group>\""},"1D3623250D0F684500981E51_comment":"AppDelegate.m","1D6058910D05DD3D006BFB54":{"isa":"PBXFileReference","explicitFileType":"wrapper.application","includeInIndex":0,"path":"\"KitchenSinktablet.app\"","sourceTree":"BUILT_PRODUCTS_DIR"},"1D6058910D05DD3D006BFB54_comment":"KitchenSinktablet.app","1DF5F4DF0D08C38300B7A737":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"UIKit.framework","path":"System/Library/Frameworks/UIKit.framework","sourceTree":"SDKROOT"},"1DF5F4DF0D08C38300B7A737_comment":"UIKit.framework","1F766FDD13BBADB100FB74C0":{"isa":"PBXFileReference","lastKnownFileType":"text.plist.strings","name":"en","path":"Localizable.strings","sourceTree":"\"<group>\""},"1F766FDD13BBADB100FB74C0_comment":"en","1F766FE013BBADB100FB74C0":{"isa":"PBXFileReference","lastKnownFileType":"text.plist.strings","name":"es","path":"Localizable.strings","sourceTree":"\"<group>\""},"1F766FE013BBADB100FB74C0_comment":"es","288765FC0DF74451002DB57D":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"CoreGraphics.framework","path":"System/Library/Frameworks/CoreGraphics.framework","sourceTree":"SDKROOT"},"288765FC0DF74451002DB57D_comment":"CoreGraphics.framework","29B97316FDCFA39411CA2CEA":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"sourcecode.c.objc","path":"main.m","sourceTree":"\"<group>\""},"29B97316FDCFA39411CA2CEA_comment":"main.m","301BF52D109A57CC0062928A":{"isa":"PBXFileReference","lastKnownFileType":"\"wrapper.pb-project\"","path":"PhoneGapLib.xcodeproj","sourceTree":"PHONEGAPLIB"},"301BF52D109A57CC0062928A_comment":"PhoneGapLib.xcodeproj","301BF56E109A69640062928A":{"isa":"PBXFileReference","lastKnownFileType":"folder","path":"www","sourceTree":"SOURCE_ROOT"},"301BF56E109A69640062928A_comment":"www","301BF5B4109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"AddressBook.framework","path":"System/Library/Frameworks/AddressBook.framework","sourceTree":"SDKROOT"},"301BF5B4109A6A2B0062928A_comment":"AddressBook.framework","301BF5B6109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"AddressBookUI.framework","path":"System/Library/Frameworks/AddressBookUI.framework","sourceTree":"SDKROOT"},"301BF5B6109A6A2B0062928A_comment":"AddressBookUI.framework","301BF5B8109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"AudioToolbox.framework","path":"System/Library/Frameworks/AudioToolbox.framework","sourceTree":"SDKROOT"},"301BF5B8109A6A2B0062928A_comment":"AudioToolbox.framework","301BF5BA109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"AVFoundation.framework","path":"System/Library/Frameworks/AVFoundation.framework","sourceTree":"SDKROOT"},"301BF5BA109A6A2B0062928A_comment":"AVFoundation.framework","301BF5BC109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"CFNetwork.framework","path":"System/Library/Frameworks/CFNetwork.framework","sourceTree":"SDKROOT"},"301BF5BC109A6A2B0062928A_comment":"CFNetwork.framework","301BF5BE109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"CoreLocation.framework","path":"System/Library/Frameworks/CoreLocation.framework","sourceTree":"SDKROOT"},"301BF5BE109A6A2B0062928A_comment":"CoreLocation.framework","301BF5C0109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"MediaPlayer.framework","path":"System/Library/Frameworks/MediaPlayer.framework","sourceTree":"SDKROOT"},"301BF5C0109A6A2B0062928A_comment":"MediaPlayer.framework","301BF5C2109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"QuartzCore.framework","path":"System/Library/Frameworks/QuartzCore.framework","sourceTree":"SDKROOT"},"301BF5C2109A6A2B0062928A_comment":"QuartzCore.framework","301BF5C4109A6A2B0062928A":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"SystemConfiguration.framework","path":"System/Library/Frameworks/SystemConfiguration.framework","sourceTree":"SDKROOT"},"301BF5C4109A6A2B0062928A_comment":"SystemConfiguration.framework","3053AC6E109B7857006FCFE7":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"text","path":"VERSION","sourceTree":"PHONEGAPLIB"},"3053AC6E109B7857006FCFE7_comment":"VERSION","305D5FD0115AB8F900A74A75":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"MobileCoreServices.framework","path":"System/Library/Frameworks/MobileCoreServices.framework","sourceTree":"SDKROOT"},"305D5FD0115AB8F900A74A75_comment":"MobileCoreServices.framework","3072F99613A8081B00425683":{"isa":"PBXFileReference","lastKnownFileType":"\"wrapper.plug-in\"","name":"Capture.bundle","path":"Resources/Capture.bundle","sourceTree":"\"<group>\""},"3072F99613A8081B00425683_comment":"Capture.bundle","307D28A1123043350040C0FA":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"text.xcconfig","path":"PhoneGapBuildSettings.xcconfig","sourceTree":"\"<group>\""},"307D28A1123043350040C0FA_comment":"PhoneGapBuildSettings.xcconfig","308D052E1370CCF300D202BF":{"isa":"PBXFileReference","lastKnownFileType":"image.png","path":"\"icon-72.png\"","sourceTree":"\"<group>\""},"308D052E1370CCF300D202BF_comment":"icon-72.png","308D052F1370CCF300D202BF":{"isa":"PBXFileReference","lastKnownFileType":"image.png","path":"icon.png","sourceTree":"\"<group>\""},"308D052F1370CCF300D202BF_comment":"icon.png","308D05301370CCF300D202BF":{"isa":"PBXFileReference","lastKnownFileType":"image.png","path":"\"icon@2x.png\"","sourceTree":"\"<group>\""},"308D05301370CCF300D202BF_comment":"icon@2x.png","308D05341370CCF300D202BF":{"isa":"PBXFileReference","lastKnownFileType":"image.png","path":"Default.png","sourceTree":"\"<group>\""},"308D05341370CCF300D202BF_comment":"Default.png","308D05351370CCF300D202BF":{"isa":"PBXFileReference","lastKnownFileType":"image.png","path":"\"Default@2x.png\"","sourceTree":"\"<group>\""},"308D05351370CCF300D202BF_comment":"Default@2x.png","30E1352610E2C1420031B30D":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"text.plist.xml","path":"PhoneGap.plist","sourceTree":"\"<group>\""},"30E1352610E2C1420031B30D_comment":"PhoneGap.plist","30E5649113A7FCAF007403D8":{"isa":"PBXFileReference","lastKnownFileType":"wrapper.framework","name":"CoreMedia.framework","path":"System/Library/Frameworks/CoreMedia.framework","sourceTree":"SDKROOT"},"30E5649113A7FCAF007403D8_comment":"CoreMedia.framework","32CA4F630368D1EE00C91783":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"sourcecode.c.h","path":"\"KitchenSinktablet-Prefix.pch\"","sourceTree":"\"<group>\""},"32CA4F630368D1EE00C91783_comment":"KitchenSinktablet-Prefix.pch","8D1107310486CEB800E47090":{"isa":"PBXFileReference","fileEncoding":4,"lastKnownFileType":"text.plist.xml","path":"\"KitchenSinktablet-Info.plist\"","plistStructureDefinitionIdentifier":"\"com.apple.xcode.plist.structure-definition.iphone.info-plist\"","sourceTree":"\"<group>\""},"8D1107310486CEB800E47090_comment":"KitchenSinktablet-Info.plist"},"PBXFrameworksBuildPhase":{"1D60588F0D05DD3D006BFB54":{"isa":"PBXFrameworksBuildPhase","buildActionMask":2147483647,"files":[{"value":"301BF552109A68D80062928A","comment":"libPhoneGap.a in Frameworks"},{"value":"1D60589F0D05DD5A006BFB54","comment":"Foundation.framework in Frameworks"},{"value":"1DF5F4E00D08C38300B7A737","comment":"UIKit.framework in Frameworks"},{"value":"288765FD0DF74451002DB57D","comment":"CoreGraphics.framework in Frameworks"},{"value":"301BF5B5109A6A2B0062928A","comment":"AddressBook.framework in Frameworks"},{"value":"301BF5B7109A6A2B0062928A","comment":"AddressBookUI.framework in Frameworks"},{"value":"301BF5B9109A6A2B0062928A","comment":"AudioToolbox.framework in Frameworks"},{"value":"301BF5BB109A6A2B0062928A","comment":"AVFoundation.framework in Frameworks"},{"value":"301BF5BD109A6A2B0062928A","comment":"CFNetwork.framework in Frameworks"},{"value":"301BF5BF109A6A2B0062928A","comment":"CoreLocation.framework in Frameworks"},{"value":"301BF5C1109A6A2B0062928A","comment":"MediaPlayer.framework in Frameworks"},{"value":"301BF5C3109A6A2B0062928A","comment":"QuartzCore.framework in Frameworks"},{"value":"301BF5C5109A6A2B0062928A","comment":"SystemConfiguration.framework in Frameworks"},{"value":"305D5FD1115AB8F900A74A75","comment":"MobileCoreServices.framework in Frameworks"},{"value":"30E5649213A7FCAF007403D8","comment":"CoreMedia.framework in Frameworks"}],"runOnlyForDeploymentPostprocessing":0},"1D60588F0D05DD3D006BFB54_comment":"Frameworks"},"PBXGroup":{"080E96DDFE201D6D7F000001":{"isa":"PBXGroup","children":[{"value":"1D3623240D0F684500981E51","comment":"AppDelegate.h"},{"value":"1D3623250D0F684500981E51","comment":"AppDelegate.m"}],"path":"Classes","sourceTree":"SOURCE_ROOT"},"080E96DDFE201D6D7F000001_comment":"Classes","19C28FACFE9D520D11CA2CBB":{"isa":"PBXGroup","children":[{"value":"1D6058910D05DD3D006BFB54","comment":"KitchenSinktablet.app"}],"name":"Products","sourceTree":"\"<group>\""},"19C28FACFE9D520D11CA2CBB_comment":"Products","1F766FDB13BBADB100FB74C0":{"isa":"PBXGroup","children":[{"value":"1F766FDC13BBADB100FB74C0","comment":"Localizable.strings"}],"name":"en.lproj","path":"Resources/en.lproj","sourceTree":"\"<group>\""},"1F766FDB13BBADB100FB74C0_comment":"en.lproj","1F766FDE13BBADB100FB74C0":{"isa":"PBXGroup","children":[{"value":"1F766FDF13BBADB100FB74C0","comment":"Localizable.strings"}],"name":"es.lproj","path":"Resources/es.lproj","sourceTree":"\"<group>\""},"1F766FDE13BBADB100FB74C0_comment":"es.lproj","29B97314FDCFA39411CA2CEA":{"isa":"PBXGroup","children":[{"value":"301BF56E109A69640062928A","comment":"www"},{"value":"301BF52D109A57CC0062928A","comment":"PhoneGapLib.xcodeproj"},{"value":"080E96DDFE201D6D7F000001","comment":"Classes"},{"value":"307C750510C5A3420062BCA9","comment":"Plugins"},{"value":"29B97315FDCFA39411CA2CEA","comment":"Other Sources"},{"value":"29B97317FDCFA39411CA2CEA","comment":"Resources"},{"value":"29B97323FDCFA39411CA2CEA","comment":"Frameworks"},{"value":"19C28FACFE9D520D11CA2CBB","comment":"Products"}],"name":"CustomTemplate","sourceTree":"\"<group>\""},"29B97314FDCFA39411CA2CEA_comment":"CustomTemplate","29B97315FDCFA39411CA2CEA":{"isa":"PBXGroup","children":[{"value":"32CA4F630368D1EE00C91783","comment":"KitchenSinktablet-Prefix.pch"},{"value":"29B97316FDCFA39411CA2CEA","comment":"main.m"}],"name":"\"Other Sources\"","sourceTree":"\"<group>\""},"29B97315FDCFA39411CA2CEA_comment":"Other Sources","29B97317FDCFA39411CA2CEA":{"isa":"PBXGroup","children":[{"value":"1F766FDB13BBADB100FB74C0","comment":"en.lproj"},{"value":"1F766FDE13BBADB100FB74C0","comment":"es.lproj"},{"value":"3072F99613A8081B00425683","comment":"Capture.bundle"},{"value":"308D052D1370CCF300D202BF","comment":"icons"},{"value":"308D05311370CCF300D202BF","comment":"splash"},{"value":"30E1352610E2C1420031B30D","comment":"PhoneGap.plist"},{"value":"3053AC6E109B7857006FCFE7","comment":"VERSION"},{"value":"8D1107310486CEB800E47090","comment":"KitchenSinktablet-Info.plist"},{"value":"307D28A1123043350040C0FA","comment":"PhoneGapBuildSettings.xcconfig"}],"name":"Resources","sourceTree":"\"<group>\""},"29B97317FDCFA39411CA2CEA_comment":"Resources","29B97323FDCFA39411CA2CEA":{"isa":"PBXGroup","children":[{"value":"1DF5F4DF0D08C38300B7A737","comment":"UIKit.framework"},{"value":"1D30AB110D05D00D00671497","comment":"Foundation.framework"},{"value":"288765FC0DF74451002DB57D","comment":"CoreGraphics.framework"},{"value":"301BF5B4109A6A2B0062928A","comment":"AddressBook.framework"},{"value":"301BF5B6109A6A2B0062928A","comment":"AddressBookUI.framework"},{"value":"301BF5B8109A6A2B0062928A","comment":"AudioToolbox.framework"},{"value":"301BF5BA109A6A2B0062928A","comment":"AVFoundation.framework"},{"value":"301BF5BC109A6A2B0062928A","comment":"CFNetwork.framework"},{"value":"301BF5BE109A6A2B0062928A","comment":"CoreLocation.framework"},{"value":"301BF5C0109A6A2B0062928A","comment":"MediaPlayer.framework"},{"value":"301BF5C2109A6A2B0062928A","comment":"QuartzCore.framework"},{"value":"301BF5C4109A6A2B0062928A","comment":"SystemConfiguration.framework"},{"value":"305D5FD0115AB8F900A74A75","comment":"MobileCoreServices.framework"},{"value":"30E5649113A7FCAF007403D8","comment":"CoreMedia.framework"}],"name":"Frameworks","sourceTree":"\"<group>\""},"29B97323FDCFA39411CA2CEA_comment":"Frameworks","301BF52E109A57CC0062928A":{"isa":"PBXGroup","children":[{"value":"301BF535109A57CC0062928A","comment":"libPhoneGap.a"},{"value":"30E47BC3136F595F00DBB853","comment":"PhoneGap.framework"}],"name":"Products","sourceTree":"\"<group>\""},"301BF52E109A57CC0062928A_comment":"Products","307C750510C5A3420062BCA9":{"isa":"PBXGroup","children":[],"path":"Plugins","sourceTree":"SOURCE_ROOT"},"307C750510C5A3420062BCA9_comment":"Plugins","308D052D1370CCF300D202BF":{"isa":"PBXGroup","children":[{"value":"308D052E1370CCF300D202BF","comment":"icon-72.png"},{"value":"308D052F1370CCF300D202BF","comment":"icon.png"},{"value":"308D05301370CCF300D202BF","comment":"icon@2x.png"}],"name":"icons","path":"Resources/icons","sourceTree":"\"<group>\""},"308D052D1370CCF300D202BF_comment":"icons","308D05311370CCF300D202BF":{"isa":"PBXGroup","children":[{"value":"308D05341370CCF300D202BF","comment":"Default.png"},{"value":"308D05351370CCF300D202BF","comment":"Default@2x.png"}],"name":"splash","path":"Resources/splash","sourceTree":"\"<group>\""},"308D05311370CCF300D202BF_comment":"splash"},"PBXNativeTarget":{"1D6058900D05DD3D006BFB54":{"isa":"PBXNativeTarget","buildConfigurationList":"1D6058960D05DD3E006BFB54","buildConfigurationList_comment":"Build configuration list for PBXNativeTarget \"KitchenSinktablet\"","buildPhases":[{"value":"304B58A110DAC018002A0835","comment":"Touch www folder"},{"value":"1D60588D0D05DD3D006BFB54","comment":"Resources"},{"value":"1D60588E0D05DD3D006BFB54","comment":"Sources"},{"value":"1D60588F0D05DD3D006BFB54","comment":"Frameworks"}],"buildRules":[],"dependencies":[{"value":"301BF551109A68C00062928A","comment":"PBXTargetDependency"}],"name":"\"KitchenSinktablet\"","productName":"\"KitchenSinktablet\"","productReference":"1D6058910D05DD3D006BFB54","productReference_comment":"KitchenSinktablet.app","productType":"\"com.apple.product-type.application\""},"1D6058900D05DD3D006BFB54_comment":"KitchenSinktablet","1D6058900D05DD3D006BFB55":{"isa":"PBXNativeTarget","buildConfigurationList":"1D6058960D05DD3E006BFB54","buildConfigurationList_comment":"Build configuration list for PBXNativeTarget \"TestApp\"","buildPhases":[{"value":"304B58A110DAC018002A0835","comment":"Touch www folder"},{"value":"1D60588D0D05DD3D006BFB54","comment":"Resources"},{"value":"1D60588E0D05DD3D006BFB54","comment":"Sources"},{"value":"1D60588F0D05DD3D006BFB54","comment":"Frameworks"}],"buildRules":[],"dependencies":[],"name":"\"TestApp\"","productName":"\"TestApp\"","productReference":"1D6058910D05DD3D006BFB54","productReference_comment":"TestApp.app","productType":"\"com.apple.product-type.application\""},"1D6058900D05DD3D006BFB55_comment":"TestApp"},"PBXProject":{"29B97313FDCFA39411CA2CEA":{"isa":"PBXProject","buildConfigurationList":"C01FCF4E08A954540054247B","buildConfigurationList_comment":"Build configuration list for PBXProject \"KitchenSinktablet\"","compatibilityVersion":"\"Xcode 3.1\"","developmentRegion":"English","hasScannedForEncodings":1,"knownRegions":["English","Japanese","French","German","en","es"],"mainGroup":"29B97314FDCFA39411CA2CEA","mainGroup_comment":"CustomTemplate","projectDirPath":"\"\"","projectReferences":[{"ProductGroup":"301BF52E109A57CC0062928A","ProductGroup_comment":"Products","ProjectRef":"301BF52D109A57CC0062928A","ProjectRef_comment":"PhoneGapLib.xcodeproj"}],"projectRoot":"\"\"","targets":[{"value":"1D6058900D05DD3D006BFB54","comment":"KitchenSinktablet"},{"value":"1D6058900D05DD3D006BFB55","comment":"TestApp"}]},"29B97313FDCFA39411CA2CEA_comment":"Project object"},"PBXReferenceProxy":{"301BF535109A57CC0062928A":{"isa":"PBXReferenceProxy","fileType":"archive.ar","path":"libPhoneGap.a","remoteRef":"301BF534109A57CC0062928A","remoteRef_comment":"PBXContainerItemProxy","sourceTree":"BUILT_PRODUCTS_DIR"},"301BF535109A57CC0062928A_comment":"libPhoneGap.a","30E47BC3136F595F00DBB853":{"isa":"PBXReferenceProxy","fileType":"wrapper.cfbundle","path":"PhoneGap.framework","remoteRef":"30E47BC2136F595F00DBB853","remoteRef_comment":"PBXContainerItemProxy","sourceTree":"BUILT_PRODUCTS_DIR"},"30E47BC3136F595F00DBB853_comment":"PhoneGap.framework"},"PBXResourcesBuildPhase":{"1D60588D0D05DD3D006BFB54":{"isa":"PBXResourcesBuildPhase","buildActionMask":2147483647,"files":[{"value":"301BF570109A69640062928A","comment":"www in Resources"},{"value":"3053AC6F109B7857006FCFE7","comment":"VERSION in Resources"},{"value":"30E1352710E2C1420031B30D","comment":"PhoneGap.plist in Resources"},{"value":"307D28A2123043360040C0FA","comment":"PhoneGapBuildSettings.xcconfig in Resources"},{"value":"308D05371370CCF300D202BF","comment":"icon-72.png in Resources"},{"value":"308D05381370CCF300D202BF","comment":"icon.png in Resources"},{"value":"308D05391370CCF300D202BF","comment":"icon@2x.png in Resources"},{"value":"308D053C1370CCF300D202BF","comment":"Default.png in Resources"},{"value":"308D053D1370CCF300D202BF","comment":"Default@2x.png in Resources"},{"value":"3072F99713A8081B00425683","comment":"Capture.bundle in Resources"},{"value":"1F766FE113BBADB100FB74C0","comment":"Localizable.strings in Resources"},{"value":"1F766FE213BBADB100FB74C0","comment":"Localizable.strings in Resources"}],"runOnlyForDeploymentPostprocessing":0},"1D60588D0D05DD3D006BFB54_comment":"Resources"},"PBXShellScriptBuildPhase":{"304B58A110DAC018002A0835":{"isa":"PBXShellScriptBuildPhase","buildActionMask":2147483647,"files":[],"inputPaths":[],"name":"\"Touch www folder\"","outputPaths":[],"runOnlyForDeploymentPostprocessing":0,"shellPath":"/bin/sh","shellScript":"\"touch -cm ${PROJECT_DIR}/www\""},"304B58A110DAC018002A0835_comment":"Touch www folder"},"PBXSourcesBuildPhase":{"1D60588E0D05DD3D006BFB54":{"isa":"PBXSourcesBuildPhase","buildActionMask":2147483647,"files":[{"value":"1D60589B0D05DD56006BFB54","comment":"main.m in Sources"},{"value":"1D3623260D0F684500981E51","comment":"AppDelegate.m in Sources"}],"runOnlyForDeploymentPostprocessing":0},"1D60588E0D05DD3D006BFB54_comment":"Sources"},"PBXTargetDependency":{"301BF551109A68C00062928A":{"isa":"PBXTargetDependency","name":"PhoneGapLib","targetProxy":"301BF550109A68C00062928A","targetProxy_comment":"PBXContainerItemProxy"},"301BF551109A68C00062928A_comment":"PBXTargetDependency"},"PBXVariantGroup":{"1F766FDC13BBADB100FB74C0":{"isa":"PBXVariantGroup","children":[{"value":"1F766FDD13BBADB100FB74C0","comment":"en"}],"name":"Localizable.strings","sourceTree":"\"<group>\""},"1F766FDC13BBADB100FB74C0_comment":"Localizable.strings","1F766FDF13BBADB100FB74C0":{"isa":"PBXVariantGroup","children":[{"value":"1F766FE013BBADB100FB74C0","comment":"es"}],"name":"Localizable.strings","sourceTree":"\"<group>\""},"1F766FDF13BBADB100FB74C0_comment":"Localizable.strings"},"XCBuildConfiguration":{"1D6058940D05DD3E006BFB54":{"isa":"XCBuildConfiguration","buildSettings":{"ALWAYS_SEARCH_USER_PATHS":"NO","ARCHS":["armv6","armv7"],"COPY_PHASE_STRIP":"NO","GCC_DYNAMIC_NO_PIC":"NO","GCC_OPTIMIZATION_LEVEL":0,"GCC_PRECOMPILE_PREFIX_HEADER":"YES","GCC_PREFIX_HEADER":"\"KitchenSinktablet-Prefix.pch\"","INFOPLIST_FILE":"\"KitchenSinktablet-Info.plist\"","IPHONEOS_DEPLOYMENT_TARGET":"3.0","ONLY_ACTIVE_ARCH":"NO","PRODUCT_NAME":"\"KitchenSinktablet\"","TARGETED_DEVICE_FAMILY":"\"1,2\""},"name":"Debug"},"1D6058940D05DD3E006BFB54_comment":"Debug","1D6058950D05DD3E006BFB54":{"isa":"XCBuildConfiguration","buildSettings":{"ALWAYS_SEARCH_USER_PATHS":"NO","ARCHS":["armv6","armv7"],"COPY_PHASE_STRIP":"YES","GCC_PRECOMPILE_PREFIX_HEADER":"YES","GCC_PREFIX_HEADER":"\"KitchenSinktablet-Prefix.pch\"","INFOPLIST_FILE":"\"KitchenSinktablet-Info.plist\"","IPHONEOS_DEPLOYMENT_TARGET":"3.0","ONLY_ACTIVE_ARCH":"NO","PRODUCT_NAME":"\"KitchenSinktablet\"","TARGETED_DEVICE_FAMILY":"\"1,2\""},"name":"Release"},"1D6058950D05DD3E006BFB54_comment":"Release","C01FCF4F08A954540054247B":{"isa":"XCBuildConfiguration","baseConfigurationReference":"307D28A1123043350040C0FA","baseConfigurationReference_comment":"PhoneGapBuildSettings.xcconfig","buildSettings":{"ARCHS":"\"$(ARCHS_STANDARD_32_BIT)\"","\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\"":"\"iPhone Distribution\"","GCC_C_LANGUAGE_STANDARD":"c99","GCC_VERSION":"com.apple.compilers.llvmgcc42","GCC_WARN_ABOUT_RETURN_TYPE":"YES","GCC_WARN_UNUSED_VARIABLE":"YES","IPHONEOS_DEPLOYMENT_TARGET":"3.0","OTHER_LDFLAGS":["\"-weak_framework\"","UIKit","\"-weak_framework\"","AVFoundation","\"-weak_framework\"","CoreMedia","\"-weak_library\"","/usr/lib/libSystem.B.dylib","\"-all_load\"","\"-Obj-C\""],"PREBINDING":"NO","SDKROOT":"iphoneos","SKIP_INSTALL":"NO","USER_HEADER_SEARCH_PATHS":"\"\"$(PHONEGAPLIB)/Classes/JSON\" \"$(PHONEGAPLIB)/Classes\"\""},"name":"Debug"},"C01FCF4F08A954540054247B_comment":"Debug","C01FCF5008A954540054247B":{"isa":"XCBuildConfiguration","baseConfigurationReference":"307D28A1123043350040C0FA","baseConfigurationReference_comment":"PhoneGapBuildSettings.xcconfig","buildSettings":{"ARCHS":"\"$(ARCHS_STANDARD_32_BIT)\"","\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\"":"\"iPhone Distribution\"","GCC_C_LANGUAGE_STANDARD":"c99","GCC_VERSION":"com.apple.compilers.llvmgcc42","GCC_WARN_ABOUT_RETURN_TYPE":"YES","GCC_WARN_UNUSED_VARIABLE":"YES","IPHONEOS_DEPLOYMENT_TARGET":"3.0","OTHER_LDFLAGS":["\"-weak_framework\"","UIKit","\"-weak_framework\"","AVFoundation","\"-weak_framework\"","CoreMedia","\"-weak_library\"","/usr/lib/libSystem.B.dylib","\"-all_load\"","\"-Obj-C\""],"PREBINDING":"NO","SDKROOT":"iphoneos","SKIP_INSTALL":"NO","USER_HEADER_SEARCH_PATHS":"\"\"$(PHONEGAPLIB)/Classes/JSON\" \"$(PHONEGAPLIB)/Classes\"\""},"name":"Release"},"C01FCF5008A954540054247B_comment":"Release"},"XCConfigurationList":{"1D6058960D05DD3E006BFB54":{"isa":"XCConfigurationList","buildConfigurations":[{"value":"1D6058940D05DD3E006BFB54","comment":"Debug"},{"value":"1D6058950D05DD3E006BFB54","comment":"Release"}],"defaultConfigurationIsVisible":0,"defaultConfigurationName":"Release"},"1D6058960D05DD3E006BFB54_comment":"Build configuration list for PBXNativeTarget \"KitchenSinktablet\"","C01FCF4E08A954540054247B":{"isa":"XCConfigurationList","buildConfigurations":[{"value":"C01FCF4F08A954540054247B","comment":"Debug"},{"value":"C01FCF5008A954540054247B","comment":"Release"}],"defaultConfigurationIsVisible":0,"defaultConfigurationName":"Release"},"C01FCF4E08A954540054247B_comment":"Build configuration list for PBXProject \"KitchenSinktablet\""}},"rootObject":"29B97313FDCFA39411CA2CEA","rootObject_comment":"Project object"},"headComment":"!$*UTF8*$!"}
+{
+  "project": {
+    "archiveVersion": 1,
+    "classes": {},
+    "objectVersion": 45,
+    "objects": {
+      "PBXBuildFile": {
+        "1D3623260D0F684500981E51": {
+          "isa": "PBXBuildFile",
+          "fileRef": "1D3623250D0F684500981E51",
+          "fileRef_comment": "AppDelegate.m"
+        },
+        "1D3623260D0F684500981E51_comment": "AppDelegate.m in Sources",
+        "1D60589B0D05DD56006BFB54": {
+          "isa": "PBXBuildFile",
+          "fileRef": "29B97316FDCFA39411CA2CEA",
+          "fileRef_comment": "main.m"
+        },
+        "1D60589B0D05DD56006BFB54_comment": "main.m in Sources",
+        "1D60589F0D05DD5A006BFB54": {
+          "isa": "PBXBuildFile",
+          "fileRef": "1D30AB110D05D00D00671497",
+          "fileRef_comment": "Foundation.framework"
+        },
+        "1D60589F0D05DD5A006BFB54_comment": "Foundation.framework in Frameworks",
+        "1DF5F4E00D08C38300B7A737": {
+          "isa": "PBXBuildFile",
+          "fileRef": "1DF5F4DF0D08C38300B7A737",
+          "fileRef_comment": "UIKit.framework",
+          "settings": {
+            "ATTRIBUTES": [
+              "Weak"
+            ]
+          }
+        },
+        "1DF5F4E00D08C38300B7A737_comment": "UIKit.framework in Frameworks",
+        "1F766FE113BBADB100FB74C0": {
+          "isa": "PBXBuildFile",
+          "fileRef": "1F766FDC13BBADB100FB74C0",
+          "fileRef_comment": "Localizable.strings"
+        },
+        "1F766FE113BBADB100FB74C0_comment": "Localizable.strings in Resources",
+        "1F766FE213BBADB100FB74C0": {
+          "isa": "PBXBuildFile",
+          "fileRef": "1F766FDF13BBADB100FB74C0",
+          "fileRef_comment": "Localizable.strings"
+        },
+        "1F766FE213BBADB100FB74C0_comment": "Localizable.strings in Resources",
+        "288765FD0DF74451002DB57D": {
+          "isa": "PBXBuildFile",
+          "fileRef": "288765FC0DF74451002DB57D",
+          "fileRef_comment": "CoreGraphics.framework"
+        },
+        "288765FD0DF74451002DB57D_comment": "CoreGraphics.framework in Frameworks",
+        "301BF552109A68D80062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF535109A57CC0062928A",
+          "fileRef_comment": "libPhoneGap.a"
+        },
+        "301BF552109A68D80062928A_comment": "libPhoneGap.a in Frameworks",
+        "301BF570109A69640062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF56E109A69640062928A",
+          "fileRef_comment": "www"
+        },
+        "301BF570109A69640062928A_comment": "www in Resources",
+        "301BF5B5109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5B4109A6A2B0062928A",
+          "fileRef_comment": "AddressBook.framework"
+        },
+        "301BF5B5109A6A2B0062928A_comment": "AddressBook.framework in Frameworks",
+        "301BF5B7109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5B6109A6A2B0062928A",
+          "fileRef_comment": "AddressBookUI.framework"
+        },
+        "301BF5B7109A6A2B0062928A_comment": "AddressBookUI.framework in Frameworks",
+        "301BF5B9109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5B8109A6A2B0062928A",
+          "fileRef_comment": "AudioToolbox.framework"
+        },
+        "301BF5B9109A6A2B0062928A_comment": "AudioToolbox.framework in Frameworks",
+        "301BF5BB109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5BA109A6A2B0062928A",
+          "fileRef_comment": "AVFoundation.framework",
+          "settings": {
+            "ATTRIBUTES": [
+              "Weak"
+            ]
+          }
+        },
+        "301BF5BB109A6A2B0062928A_comment": "AVFoundation.framework in Frameworks",
+        "301BF5BD109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5BC109A6A2B0062928A",
+          "fileRef_comment": "CFNetwork.framework"
+        },
+        "301BF5BD109A6A2B0062928A_comment": "CFNetwork.framework in Frameworks",
+        "301BF5BF109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5BE109A6A2B0062928A",
+          "fileRef_comment": "CoreLocation.framework"
+        },
+        "301BF5BF109A6A2B0062928A_comment": "CoreLocation.framework in Frameworks",
+        "301BF5C1109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5C0109A6A2B0062928A",
+          "fileRef_comment": "MediaPlayer.framework"
+        },
+        "301BF5C1109A6A2B0062928A_comment": "MediaPlayer.framework in Frameworks",
+        "301BF5C3109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5C2109A6A2B0062928A",
+          "fileRef_comment": "QuartzCore.framework"
+        },
+        "301BF5C3109A6A2B0062928A_comment": "QuartzCore.framework in Frameworks",
+        "301BF5C5109A6A2B0062928A": {
+          "isa": "PBXBuildFile",
+          "fileRef": "301BF5C4109A6A2B0062928A",
+          "fileRef_comment": "SystemConfiguration.framework"
+        },
+        "301BF5C5109A6A2B0062928A_comment": "SystemConfiguration.framework in Frameworks",
+        "3053AC6F109B7857006FCFE7": {
+          "isa": "PBXBuildFile",
+          "fileRef": "3053AC6E109B7857006FCFE7",
+          "fileRef_comment": "VERSION"
+        },
+        "3053AC6F109B7857006FCFE7_comment": "VERSION in Resources",
+        "305D5FD1115AB8F900A74A75": {
+          "isa": "PBXBuildFile",
+          "fileRef": "305D5FD0115AB8F900A74A75",
+          "fileRef_comment": "MobileCoreServices.framework"
+        },
+        "305D5FD1115AB8F900A74A75_comment": "MobileCoreServices.framework in Frameworks",
+        "3072F99713A8081B00425683": {
+          "isa": "PBXBuildFile",
+          "fileRef": "3072F99613A8081B00425683",
+          "fileRef_comment": "Capture.bundle"
+        },
+        "3072F99713A8081B00425683_comment": "Capture.bundle in Resources",
+        "307D28A2123043360040C0FA": {
+          "isa": "PBXBuildFile",
+          "fileRef": "307D28A1123043350040C0FA",
+          "fileRef_comment": "PhoneGapBuildSettings.xcconfig"
+        },
+        "307D28A2123043360040C0FA_comment": "PhoneGapBuildSettings.xcconfig in Resources",
+        "308D05371370CCF300D202BF": {
+          "isa": "PBXBuildFile",
+          "fileRef": "308D052E1370CCF300D202BF",
+          "fileRef_comment": "icon-72.png"
+        },
+        "308D05371370CCF300D202BF_comment": "icon-72.png in Resources",
+        "308D05381370CCF300D202BF": {
+          "isa": "PBXBuildFile",
+          "fileRef": "308D052F1370CCF300D202BF",
+          "fileRef_comment": "icon.png"
+        },
+        "308D05381370CCF300D202BF_comment": "icon.png in Resources",
+        "308D05391370CCF300D202BF": {
+          "isa": "PBXBuildFile",
+          "fileRef": "308D05301370CCF300D202BF",
+          "fileRef_comment": "icon@2x.png"
+        },
+        "308D05391370CCF300D202BF_comment": "icon@2x.png in Resources",
+        "308D053C1370CCF300D202BF": {
+          "isa": "PBXBuildFile",
+          "fileRef": "308D05341370CCF300D202BF",
+          "fileRef_comment": "Default.png"
+        },
+        "308D053C1370CCF300D202BF_comment": "Default.png in Resources",
+        "308D053D1370CCF300D202BF": {
+          "isa": "PBXBuildFile",
+          "fileRef": "308D05351370CCF300D202BF",
+          "fileRef_comment": "Default@2x.png"
+        },
+        "308D053D1370CCF300D202BF_comment": "Default@2x.png in Resources",
+        "30E1352710E2C1420031B30D": {
+          "isa": "PBXBuildFile",
+          "fileRef": "30E1352610E2C1420031B30D",
+          "fileRef_comment": "PhoneGap.plist"
+        },
+        "30E1352710E2C1420031B30D_comment": "PhoneGap.plist in Resources",
+        "30E5649213A7FCAF007403D8": {
+          "isa": "PBXBuildFile",
+          "fileRef": "30E5649113A7FCAF007403D8",
+          "fileRef_comment": "CoreMedia.framework",
+          "settings": {
+            "ATTRIBUTES": [
+              "Weak"
+            ]
+          }
+        },
+        "30E5649213A7FCAF007403D8_comment": "CoreMedia.framework in Frameworks"
+      },
+      "PBXContainerItemProxy": {
+        "301BF534109A57CC0062928A": {
+          "isa": "PBXContainerItemProxy",
+          "containerPortal": "301BF52D109A57CC0062928A",
+          "containerPortal_comment": "PhoneGapLib.xcodeproj",
+          "proxyType": 2,
+          "remoteGlobalIDString": "D2AAC07E0554694100DB518D",
+          "remoteInfo": "PhoneGapLib"
+        },
+        "301BF534109A57CC0062928A_comment": "PBXContainerItemProxy",
+        "301BF550109A68C00062928A": {
+          "isa": "PBXContainerItemProxy",
+          "containerPortal": "301BF52D109A57CC0062928A",
+          "containerPortal_comment": "PhoneGapLib.xcodeproj",
+          "proxyType": 1,
+          "remoteGlobalIDString": "D2AAC07D0554694100DB518D",
+          "remoteInfo": "PhoneGapLib"
+        },
+        "301BF550109A68C00062928A_comment": "PBXContainerItemProxy",
+        "30E47BC2136F595F00DBB853": {
+          "isa": "PBXContainerItemProxy",
+          "containerPortal": "301BF52D109A57CC0062928A",
+          "containerPortal_comment": "PhoneGapLib.xcodeproj",
+          "proxyType": 2,
+          "remoteGlobalIDString": "303258D8136B2C9400982B63",
+          "remoteInfo": "PhoneGap"
+        },
+        "30E47BC2136F595F00DBB853_comment": "PBXContainerItemProxy"
+      },
+      "PBXCopyFilesBuildPhase": {
+        "73E82FF51BCF133B004E733B": {
+          "isa": "PBXCopyFilesBuildPhase",
+          "buildActionMask": 2147483647,
+          "dstPath": "\"\"",
+          "dstSubfolderSpec": 10,
+          "files": [],
+          "name": "\"Embed Frameworks\"",
+          "runOnlyForDeploymentPostprocessing": 0
+        },
+        "73E82FF51BCF133B004E733B_comment": "Embed Frameworks"
+      },
+      "PBXFileReference": {
+        "1D30AB110D05D00D00671497": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "Foundation.framework",
+          "path": "System/Library/Frameworks/Foundation.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "1D30AB110D05D00D00671497_comment": "Foundation.framework",
+        "1D3623240D0F684500981E51": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "sourcecode.c.h",
+          "path": "AppDelegate.h",
+          "sourceTree": "\"<group>\""
+        },
+        "1D3623240D0F684500981E51_comment": "AppDelegate.h",
+        "1D3623250D0F684500981E51": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "sourcecode.c.objc",
+          "path": "AppDelegate.m",
+          "sourceTree": "\"<group>\""
+        },
+        "1D3623250D0F684500981E51_comment": "AppDelegate.m",
+        "1D6058910D05DD3D006BFB54": {
+          "isa": "PBXFileReference",
+          "explicitFileType": "wrapper.application",
+          "includeInIndex": 0,
+          "path": "\"KitchenSinktablet.app\"",
+          "sourceTree": "BUILT_PRODUCTS_DIR"
+        },
+        "1D6058910D05DD3D006BFB54_comment": "KitchenSinktablet.app",
+        "1DF5F4DF0D08C38300B7A737": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "UIKit.framework",
+          "path": "System/Library/Frameworks/UIKit.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "1DF5F4DF0D08C38300B7A737_comment": "UIKit.framework",
+        "1F766FDD13BBADB100FB74C0": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "text.plist.strings",
+          "name": "en",
+          "path": "Localizable.strings",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FDD13BBADB100FB74C0_comment": "en",
+        "1F766FE013BBADB100FB74C0": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "text.plist.strings",
+          "name": "es",
+          "path": "Localizable.strings",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FE013BBADB100FB74C0_comment": "es",
+        "288765FC0DF74451002DB57D": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "CoreGraphics.framework",
+          "path": "System/Library/Frameworks/CoreGraphics.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "288765FC0DF74451002DB57D_comment": "CoreGraphics.framework",
+        "29B97316FDCFA39411CA2CEA": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "sourcecode.c.objc",
+          "path": "main.m",
+          "sourceTree": "\"<group>\""
+        },
+        "29B97316FDCFA39411CA2CEA_comment": "main.m",
+        "301BF52D109A57CC0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "\"wrapper.pb-project\"",
+          "path": "PhoneGapLib.xcodeproj",
+          "sourceTree": "PHONEGAPLIB"
+        },
+        "301BF52D109A57CC0062928A_comment": "PhoneGapLib.xcodeproj",
+        "301BF56E109A69640062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "folder",
+          "path": "www",
+          "sourceTree": "SOURCE_ROOT"
+        },
+        "301BF56E109A69640062928A_comment": "www",
+        "301BF5B4109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "AddressBook.framework",
+          "path": "System/Library/Frameworks/AddressBook.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5B4109A6A2B0062928A_comment": "AddressBook.framework",
+        "301BF5B6109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "AddressBookUI.framework",
+          "path": "System/Library/Frameworks/AddressBookUI.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5B6109A6A2B0062928A_comment": "AddressBookUI.framework",
+        "301BF5B8109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "AudioToolbox.framework",
+          "path": "System/Library/Frameworks/AudioToolbox.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5B8109A6A2B0062928A_comment": "AudioToolbox.framework",
+        "301BF5BA109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "AVFoundation.framework",
+          "path": "System/Library/Frameworks/AVFoundation.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5BA109A6A2B0062928A_comment": "AVFoundation.framework",
+        "301BF5BC109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "CFNetwork.framework",
+          "path": "System/Library/Frameworks/CFNetwork.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5BC109A6A2B0062928A_comment": "CFNetwork.framework",
+        "301BF5BE109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "CoreLocation.framework",
+          "path": "System/Library/Frameworks/CoreLocation.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5BE109A6A2B0062928A_comment": "CoreLocation.framework",
+        "301BF5C0109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "MediaPlayer.framework",
+          "path": "System/Library/Frameworks/MediaPlayer.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5C0109A6A2B0062928A_comment": "MediaPlayer.framework",
+        "301BF5C2109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "QuartzCore.framework",
+          "path": "System/Library/Frameworks/QuartzCore.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5C2109A6A2B0062928A_comment": "QuartzCore.framework",
+        "301BF5C4109A6A2B0062928A": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "SystemConfiguration.framework",
+          "path": "System/Library/Frameworks/SystemConfiguration.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "301BF5C4109A6A2B0062928A_comment": "SystemConfiguration.framework",
+        "3053AC6E109B7857006FCFE7": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "text",
+          "path": "VERSION",
+          "sourceTree": "PHONEGAPLIB"
+        },
+        "3053AC6E109B7857006FCFE7_comment": "VERSION",
+        "305D5FD0115AB8F900A74A75": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "MobileCoreServices.framework",
+          "path": "System/Library/Frameworks/MobileCoreServices.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "305D5FD0115AB8F900A74A75_comment": "MobileCoreServices.framework",
+        "3072F99613A8081B00425683": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "\"wrapper.plug-in\"",
+          "name": "Capture.bundle",
+          "path": "Resources/Capture.bundle",
+          "sourceTree": "\"<group>\""
+        },
+        "3072F99613A8081B00425683_comment": "Capture.bundle",
+        "307D28A1123043350040C0FA": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "text.xcconfig",
+          "path": "PhoneGapBuildSettings.xcconfig",
+          "sourceTree": "\"<group>\""
+        },
+        "307D28A1123043350040C0FA_comment": "PhoneGapBuildSettings.xcconfig",
+        "308D052E1370CCF300D202BF": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "image.png",
+          "path": "\"icon-72.png\"",
+          "sourceTree": "\"<group>\""
+        },
+        "308D052E1370CCF300D202BF_comment": "icon-72.png",
+        "308D052F1370CCF300D202BF": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "image.png",
+          "path": "icon.png",
+          "sourceTree": "\"<group>\""
+        },
+        "308D052F1370CCF300D202BF_comment": "icon.png",
+        "308D05301370CCF300D202BF": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "image.png",
+          "path": "\"icon@2x.png\"",
+          "sourceTree": "\"<group>\""
+        },
+        "308D05301370CCF300D202BF_comment": "icon@2x.png",
+        "308D05341370CCF300D202BF": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "image.png",
+          "path": "Default.png",
+          "sourceTree": "\"<group>\""
+        },
+        "308D05341370CCF300D202BF_comment": "Default.png",
+        "308D05351370CCF300D202BF": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "image.png",
+          "path": "\"Default@2x.png\"",
+          "sourceTree": "\"<group>\""
+        },
+        "308D05351370CCF300D202BF_comment": "Default@2x.png",
+        "30E1352610E2C1420031B30D": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "text.plist.xml",
+          "path": "PhoneGap.plist",
+          "sourceTree": "\"<group>\""
+        },
+        "30E1352610E2C1420031B30D_comment": "PhoneGap.plist",
+        "30E5649113A7FCAF007403D8": {
+          "isa": "PBXFileReference",
+          "lastKnownFileType": "wrapper.framework",
+          "name": "CoreMedia.framework",
+          "path": "System/Library/Frameworks/CoreMedia.framework",
+          "sourceTree": "SDKROOT"
+        },
+        "30E5649113A7FCAF007403D8_comment": "CoreMedia.framework",
+        "32CA4F630368D1EE00C91783": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "sourcecode.c.h",
+          "path": "\"KitchenSinktablet-Prefix.pch\"",
+          "sourceTree": "\"<group>\""
+        },
+        "32CA4F630368D1EE00C91783_comment": "KitchenSinktablet-Prefix.pch",
+        "8D1107310486CEB800E47090": {
+          "isa": "PBXFileReference",
+          "fileEncoding": 4,
+          "lastKnownFileType": "text.plist.xml",
+          "path": "\"KitchenSinktablet-Info.plist\"",
+          "plistStructureDefinitionIdentifier": "\"com.apple.xcode.plist.structure-definition.iphone.info-plist\"",
+          "sourceTree": "\"<group>\""
+        },
+        "8D1107310486CEB800E47090_comment": "KitchenSinktablet-Info.plist"
+      },
+      "PBXFrameworksBuildPhase": {
+        "1D60588F0D05DD3D006BFB54": {
+          "isa": "PBXFrameworksBuildPhase",
+          "buildActionMask": 2147483647,
+          "files": [
+            {
+              "value": "301BF552109A68D80062928A",
+              "comment": "libPhoneGap.a in Frameworks"
+            },
+            {
+              "value": "1D60589F0D05DD5A006BFB54",
+              "comment": "Foundation.framework in Frameworks"
+            },
+            {
+              "value": "1DF5F4E00D08C38300B7A737",
+              "comment": "UIKit.framework in Frameworks"
+            },
+            {
+              "value": "288765FD0DF74451002DB57D",
+              "comment": "CoreGraphics.framework in Frameworks"
+            },
+            {
+              "value": "301BF5B5109A6A2B0062928A",
+              "comment": "AddressBook.framework in Frameworks"
+            },
+            {
+              "value": "301BF5B7109A6A2B0062928A",
+              "comment": "AddressBookUI.framework in Frameworks"
+            },
+            {
+              "value": "301BF5B9109A6A2B0062928A",
+              "comment": "AudioToolbox.framework in Frameworks"
+            },
+            {
+              "value": "301BF5BB109A6A2B0062928A",
+              "comment": "AVFoundation.framework in Frameworks"
+            },
+            {
+              "value": "301BF5BD109A6A2B0062928A",
+              "comment": "CFNetwork.framework in Frameworks"
+            },
+            {
+              "value": "301BF5BF109A6A2B0062928A",
+              "comment": "CoreLocation.framework in Frameworks"
+            },
+            {
+              "value": "301BF5C1109A6A2B0062928A",
+              "comment": "MediaPlayer.framework in Frameworks"
+            },
+            {
+              "value": "301BF5C3109A6A2B0062928A",
+              "comment": "QuartzCore.framework in Frameworks"
+            },
+            {
+              "value": "301BF5C5109A6A2B0062928A",
+              "comment": "SystemConfiguration.framework in Frameworks"
+            },
+            {
+              "value": "305D5FD1115AB8F900A74A75",
+              "comment": "MobileCoreServices.framework in Frameworks"
+            },
+            {
+              "value": "30E5649213A7FCAF007403D8",
+              "comment": "CoreMedia.framework in Frameworks"
+            }
+          ],
+          "runOnlyForDeploymentPostprocessing": 0
+        },
+        "1D60588F0D05DD3D006BFB54_comment": "Frameworks"
+      },
+      "PBXGroup": {
+        "080E96DDFE201D6D7F000001": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1D3623240D0F684500981E51",
+              "comment": "AppDelegate.h"
+            },
+            {
+              "value": "1D3623250D0F684500981E51",
+              "comment": "AppDelegate.m"
+            }
+          ],
+          "path": "Classes",
+          "sourceTree": "SOURCE_ROOT"
+        },
+        "080E96DDFE201D6D7F000001_comment": "Classes",
+        "19C28FACFE9D520D11CA2CBB": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1D6058910D05DD3D006BFB54",
+              "comment": "KitchenSinktablet.app"
+            }
+          ],
+          "name": "Products",
+          "sourceTree": "\"<group>\""
+        },
+        "19C28FACFE9D520D11CA2CBB_comment": "Products",
+        "1F766FDB13BBADB100FB74C0": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1F766FDC13BBADB100FB74C0",
+              "comment": "Localizable.strings"
+            }
+          ],
+          "name": "en.lproj",
+          "path": "Resources/en.lproj",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FDB13BBADB100FB74C0_comment": "en.lproj",
+        "1F766FDE13BBADB100FB74C0": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1F766FDF13BBADB100FB74C0",
+              "comment": "Localizable.strings"
+            }
+          ],
+          "name": "es.lproj",
+          "path": "Resources/es.lproj",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FDE13BBADB100FB74C0_comment": "es.lproj",
+        "29B97314FDCFA39411CA2CEA": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "301BF56E109A69640062928A",
+              "comment": "www"
+            },
+            {
+              "value": "301BF52D109A57CC0062928A",
+              "comment": "PhoneGapLib.xcodeproj"
+            },
+            {
+              "value": "080E96DDFE201D6D7F000001",
+              "comment": "Classes"
+            },
+            {
+              "value": "307C750510C5A3420062BCA9",
+              "comment": "Plugins"
+            },
+            {
+              "value": "29B97315FDCFA39411CA2CEA",
+              "comment": "Other Sources"
+            },
+            {
+              "value": "29B97317FDCFA39411CA2CEA",
+              "comment": "Resources"
+            },
+            {
+              "value": "29B97323FDCFA39411CA2CEA",
+              "comment": "Frameworks"
+            },
+            {
+              "value": "19C28FACFE9D520D11CA2CBB",
+              "comment": "Products"
+            }
+          ],
+          "name": "CustomTemplate",
+          "sourceTree": "\"<group>\""
+        },
+        "29B97314FDCFA39411CA2CEA_comment": "CustomTemplate",
+        "29B97315FDCFA39411CA2CEA": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "32CA4F630368D1EE00C91783",
+              "comment": "KitchenSinktablet-Prefix.pch"
+            },
+            {
+              "value": "29B97316FDCFA39411CA2CEA",
+              "comment": "main.m"
+            }
+          ],
+          "name": "\"Other Sources\"",
+          "sourceTree": "\"<group>\""
+        },
+        "29B97315FDCFA39411CA2CEA_comment": "Other Sources",
+        "29B97317FDCFA39411CA2CEA": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1F766FDB13BBADB100FB74C0",
+              "comment": "en.lproj"
+            },
+            {
+              "value": "1F766FDE13BBADB100FB74C0",
+              "comment": "es.lproj"
+            },
+            {
+              "value": "3072F99613A8081B00425683",
+              "comment": "Capture.bundle"
+            },
+            {
+              "value": "308D052D1370CCF300D202BF",
+              "comment": "icons"
+            },
+            {
+              "value": "308D05311370CCF300D202BF",
+              "comment": "splash"
+            },
+            {
+              "value": "30E1352610E2C1420031B30D",
+              "comment": "PhoneGap.plist"
+            },
+            {
+              "value": "3053AC6E109B7857006FCFE7",
+              "comment": "VERSION"
+            },
+            {
+              "value": "8D1107310486CEB800E47090",
+              "comment": "KitchenSinktablet-Info.plist"
+            },
+            {
+              "value": "307D28A1123043350040C0FA",
+              "comment": "PhoneGapBuildSettings.xcconfig"
+            }
+          ],
+          "name": "Resources",
+          "sourceTree": "\"<group>\""
+        },
+        "29B97317FDCFA39411CA2CEA_comment": "Resources",
+        "29B97323FDCFA39411CA2CEA": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "1DF5F4DF0D08C38300B7A737",
+              "comment": "UIKit.framework"
+            },
+            {
+              "value": "1D30AB110D05D00D00671497",
+              "comment": "Foundation.framework"
+            },
+            {
+              "value": "288765FC0DF74451002DB57D",
+              "comment": "CoreGraphics.framework"
+            },
+            {
+              "value": "301BF5B4109A6A2B0062928A",
+              "comment": "AddressBook.framework"
+            },
+            {
+              "value": "301BF5B6109A6A2B0062928A",
+              "comment": "AddressBookUI.framework"
+            },
+            {
+              "value": "301BF5B8109A6A2B0062928A",
+              "comment": "AudioToolbox.framework"
+            },
+            {
+              "value": "301BF5BA109A6A2B0062928A",
+              "comment": "AVFoundation.framework"
+            },
+            {
+              "value": "301BF5BC109A6A2B0062928A",
+              "comment": "CFNetwork.framework"
+            },
+            {
+              "value": "301BF5BE109A6A2B0062928A",
+              "comment": "CoreLocation.framework"
+            },
+            {
+              "value": "301BF5C0109A6A2B0062928A",
+              "comment": "MediaPlayer.framework"
+            },
+            {
+              "value": "301BF5C2109A6A2B0062928A",
+              "comment": "QuartzCore.framework"
+            },
+            {
+              "value": "301BF5C4109A6A2B0062928A",
+              "comment": "SystemConfiguration.framework"
+            },
+            {
+              "value": "305D5FD0115AB8F900A74A75",
+              "comment": "MobileCoreServices.framework"
+            },
+            {
+              "value": "30E5649113A7FCAF007403D8",
+              "comment": "CoreMedia.framework"
+            }
+          ],
+          "name": "Frameworks",
+          "sourceTree": "\"<group>\""
+        },
+        "29B97323FDCFA39411CA2CEA_comment": "Frameworks",
+        "301BF52E109A57CC0062928A": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "301BF535109A57CC0062928A",
+              "comment": "libPhoneGap.a"
+            },
+            {
+              "value": "30E47BC3136F595F00DBB853",
+              "comment": "PhoneGap.framework"
+            }
+          ],
+          "name": "Products",
+          "sourceTree": "\"<group>\""
+        },
+        "301BF52E109A57CC0062928A_comment": "Products",
+        "307C750510C5A3420062BCA9": {
+          "isa": "PBXGroup",
+          "children": [],
+          "path": "Plugins",
+          "sourceTree": "SOURCE_ROOT"
+        },
+        "307C750510C5A3420062BCA9_comment": "Plugins",
+        "308D052D1370CCF300D202BF": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "308D052E1370CCF300D202BF",
+              "comment": "icon-72.png"
+            },
+            {
+              "value": "308D052F1370CCF300D202BF",
+              "comment": "icon.png"
+            },
+            {
+              "value": "308D05301370CCF300D202BF",
+              "comment": "icon@2x.png"
+            }
+          ],
+          "name": "icons",
+          "path": "Resources/icons",
+          "sourceTree": "\"<group>\""
+        },
+        "308D052D1370CCF300D202BF_comment": "icons",
+        "308D05311370CCF300D202BF": {
+          "isa": "PBXGroup",
+          "children": [
+            {
+              "value": "308D05341370CCF300D202BF",
+              "comment": "Default.png"
+            },
+            {
+              "value": "308D05351370CCF300D202BF",
+              "comment": "Default@2x.png"
+            }
+          ],
+          "name": "splash",
+          "path": "Resources/splash",
+          "sourceTree": "\"<group>\""
+        },
+        "308D05311370CCF300D202BF_comment": "splash"
+      },
+      "PBXNativeTarget": {
+        "1D6058900D05DD3D006BFB54": {
+          "isa": "PBXNativeTarget",
+          "buildConfigurationList": "1D6058960D05DD3E006BFB54",
+          "buildConfigurationList_comment": "Build configuration list for PBXNativeTarget \"KitchenSinktablet\"",
+          "buildPhases": [
+            {
+              "value": "304B58A110DAC018002A0835",
+              "comment": "Touch www folder"
+            },
+            {
+              "value": "1D60588D0D05DD3D006BFB54",
+              "comment": "Resources"
+            },
+            {
+              "value": "1D60588E0D05DD3D006BFB54",
+              "comment": "Sources"
+            },
+            {
+              "value": "1D60588F0D05DD3D006BFB54",
+              "comment": "Frameworks"
+            }
+          ],
+          "buildRules": [],
+          "dependencies": [
+            {
+              "value": "301BF551109A68C00062928A",
+              "comment": "PBXTargetDependency"
+            }
+          ],
+          "name": "\"KitchenSinktablet\"",
+          "productName": "\"KitchenSinktablet\"",
+          "productReference": "1D6058910D05DD3D006BFB54",
+          "productReference_comment": "KitchenSinktablet.app",
+          "productType": "\"com.apple.product-type.application\""
+        },
+        "1D6058900D05DD3D006BFB54_comment": "KitchenSinktablet",
+        "1D6058900D05DD3D006BFB55": {
+          "isa": "PBXNativeTarget",
+          "buildConfigurationList": "1D6058960D05DD3E006BFB54",
+          "buildConfigurationList_comment": "Build configuration list for PBXNativeTarget \"TestApp\"",
+          "buildPhases": [
+            {
+              "value": "304B58A110DAC018002A0835",
+              "comment": "Touch www folder"
+            },
+            {
+              "value": "1D60588D0D05DD3D006BFB54",
+              "comment": "Resources"
+            },
+            {
+              "value": "1D60588E0D05DD3D006BFB54",
+              "comment": "Sources"
+            },
+            {
+              "value": "1D60588F0D05DD3D006BFB54",
+              "comment": "Frameworks"
+            }
+          ],
+          "buildRules": [],
+          "dependencies": [],
+          "name": "\"TestApp\"",
+          "productName": "\"TestApp\"",
+          "productReference": "1D6058910D05DD3D006BFB54",
+          "productReference_comment": "TestApp.app",
+          "productType": "\"com.apple.product-type.application\""
+        },
+        "1D6058900D05DD3D006BFB55_comment": "TestApp"
+      },
+      "PBXProject": {
+        "29B97313FDCFA39411CA2CEA": {
+          "isa": "PBXProject",
+          "buildConfigurationList": "C01FCF4E08A954540054247B",
+          "buildConfigurationList_comment": "Build configuration list for PBXProject \"KitchenSinktablet\"",
+          "compatibilityVersion": "\"Xcode 3.1\"",
+          "developmentRegion": "English",
+          "hasScannedForEncodings": 1,
+          "knownRegions": [
+            "English",
+            "Japanese",
+            "French",
+            "German",
+            "en",
+            "es"
+          ],
+          "mainGroup": "29B97314FDCFA39411CA2CEA",
+          "mainGroup_comment": "CustomTemplate",
+          "projectDirPath": "\"\"",
+          "projectReferences": [
+            {
+              "ProductGroup": "301BF52E109A57CC0062928A",
+              "ProductGroup_comment": "Products",
+              "ProjectRef": "301BF52D109A57CC0062928A",
+              "ProjectRef_comment": "PhoneGapLib.xcodeproj"
+            }
+          ],
+          "projectRoot": "\"\"",
+          "targets": [
+            {
+              "value": "1D6058900D05DD3D006BFB54",
+              "comment": "KitchenSinktablet"
+            },
+            {
+              "value": "1D6058900D05DD3D006BFB55",
+              "comment": "TestApp"
+            }
+          ]
+        },
+        "29B97313FDCFA39411CA2CEA_comment": "Project object"
+      },
+      "PBXReferenceProxy": {
+        "301BF535109A57CC0062928A": {
+          "isa": "PBXReferenceProxy",
+          "fileType": "archive.ar",
+          "path": "libPhoneGap.a",
+          "remoteRef": "301BF534109A57CC0062928A",
+          "remoteRef_comment": "PBXContainerItemProxy",
+          "sourceTree": "BUILT_PRODUCTS_DIR"
+        },
+        "301BF535109A57CC0062928A_comment": "libPhoneGap.a",
+        "30E47BC3136F595F00DBB853": {
+          "isa": "PBXReferenceProxy",
+          "fileType": "wrapper.cfbundle",
+          "path": "PhoneGap.framework",
+          "remoteRef": "30E47BC2136F595F00DBB853",
+          "remoteRef_comment": "PBXContainerItemProxy",
+          "sourceTree": "BUILT_PRODUCTS_DIR"
+        },
+        "30E47BC3136F595F00DBB853_comment": "PhoneGap.framework"
+      },
+      "PBXResourcesBuildPhase": {
+        "1D60588D0D05DD3D006BFB54": {
+          "isa": "PBXResourcesBuildPhase",
+          "buildActionMask": 2147483647,
+          "files": [
+            {
+              "value": "301BF570109A69640062928A",
+              "comment": "www in Resources"
+            },
+            {
+              "value": "3053AC6F109B7857006FCFE7",
+              "comment": "VERSION in Resources"
+            },
+            {
+              "value": "30E1352710E2C1420031B30D",
+              "comment": "PhoneGap.plist in Resources"
+            },
+            {
+              "value": "307D28A2123043360040C0FA",
+              "comment": "PhoneGapBuildSettings.xcconfig in Resources"
+            },
+            {
+              "value": "308D05371370CCF300D202BF",
+              "comment": "icon-72.png in Resources"
+            },
+            {
+              "value": "308D05381370CCF300D202BF",
+              "comment": "icon.png in Resources"
+            },
+            {
+              "value": "308D05391370CCF300D202BF",
+              "comment": "icon@2x.png in Resources"
+            },
+            {
+              "value": "308D053C1370CCF300D202BF",
+              "comment": "Default.png in Resources"
+            },
+            {
+              "value": "308D053D1370CCF300D202BF",
+              "comment": "Default@2x.png in Resources"
+            },
+            {
+              "value": "3072F99713A8081B00425683",
+              "comment": "Capture.bundle in Resources"
+            },
+            {
+              "value": "1F766FE113BBADB100FB74C0",
+              "comment": "Localizable.strings in Resources"
+            },
+            {
+              "value": "1F766FE213BBADB100FB74C0",
+              "comment": "Localizable.strings in Resources"
+            }
+          ],
+          "runOnlyForDeploymentPostprocessing": 0
+        },
+        "1D60588D0D05DD3D006BFB54_comment": "Resources"
+      },
+      "PBXShellScriptBuildPhase": {
+        "304B58A110DAC018002A0835": {
+          "isa": "PBXShellScriptBuildPhase",
+          "buildActionMask": 2147483647,
+          "files": [],
+          "inputPaths": [],
+          "name": "\"Touch www folder\"",
+          "outputPaths": [],
+          "runOnlyForDeploymentPostprocessing": 0,
+          "shellPath": "/bin/sh",
+          "shellScript": "\"touch -cm ${PROJECT_DIR}/www\""
+        },
+        "304B58A110DAC018002A0835_comment": "Touch www folder"
+      },
+      "PBXSourcesBuildPhase": {
+        "1D60588E0D05DD3D006BFB54": {
+          "isa": "PBXSourcesBuildPhase",
+          "buildActionMask": 2147483647,
+          "files": [
+            {
+              "value": "1D60589B0D05DD56006BFB54",
+              "comment": "main.m in Sources"
+            },
+            {
+              "value": "1D3623260D0F684500981E51",
+              "comment": "AppDelegate.m in Sources"
+            }
+          ],
+          "runOnlyForDeploymentPostprocessing": 0
+        },
+        "1D60588E0D05DD3D006BFB54_comment": "Sources"
+      },
+      "PBXTargetDependency": {
+        "301BF551109A68C00062928A": {
+          "isa": "PBXTargetDependency",
+          "name": "PhoneGapLib",
+          "targetProxy": "301BF550109A68C00062928A",
+          "targetProxy_comment": "PBXContainerItemProxy"
+        },
+        "301BF551109A68C00062928A_comment": "PBXTargetDependency"
+      },
+      "PBXVariantGroup": {
+        "1F766FDC13BBADB100FB74C0": {
+          "isa": "PBXVariantGroup",
+          "children": [
+            {
+              "value": "1F766FDD13BBADB100FB74C0",
+              "comment": "en"
+            }
+          ],
+          "name": "Localizable.strings",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FDC13BBADB100FB74C0_comment": "Localizable.strings",
+        "1F766FDF13BBADB100FB74C0": {
+          "isa": "PBXVariantGroup",
+          "children": [
+            {
+              "value": "1F766FE013BBADB100FB74C0",
+              "comment": "es"
+            }
+          ],
+          "name": "Localizable.strings",
+          "sourceTree": "\"<group>\""
+        },
+        "1F766FDF13BBADB100FB74C0_comment": "Localizable.strings"
+      },
+      "XCBuildConfiguration": {
+        "1D6058940D05DD3E006BFB54": {
+          "isa": "XCBuildConfiguration",
+          "buildSettings": {
+            "ALWAYS_SEARCH_USER_PATHS": "NO",
+            "ARCHS": [
+              "armv6",
+              "armv7"
+            ],
+            "COPY_PHASE_STRIP": "NO",
+            "GCC_DYNAMIC_NO_PIC": "NO",
+            "GCC_OPTIMIZATION_LEVEL": 0,
+            "GCC_PRECOMPILE_PREFIX_HEADER": "YES",
+            "GCC_PREFIX_HEADER": "\"KitchenSinktablet-Prefix.pch\"",
+            "INFOPLIST_FILE": "\"KitchenSinktablet-Info.plist\"",
+            "IPHONEOS_DEPLOYMENT_TARGET": "3.0",
+            "ONLY_ACTIVE_ARCH": "NO",
+            "PRODUCT_NAME": "\"KitchenSinktablet\"",
+            "TARGETED_DEVICE_FAMILY": "\"1,2\""
+          },
+          "name": "Debug"
+        },
+        "1D6058940D05DD3E006BFB54_comment": "Debug",
+        "1D6058950D05DD3E006BFB54": {
+          "isa": "XCBuildConfiguration",
+          "buildSettings": {
+            "ALWAYS_SEARCH_USER_PATHS": "NO",
+            "ARCHS": [
+              "armv6",
+              "armv7"
+            ],
+            "COPY_PHASE_STRIP": "YES",
+            "GCC_PRECOMPILE_PREFIX_HEADER": "YES",
+            "GCC_PREFIX_HEADER": "\"KitchenSinktablet-Prefix.pch\"",
+            "INFOPLIST_FILE": "\"KitchenSinktablet-Info.plist\"",
+            "IPHONEOS_DEPLOYMENT_TARGET": "3.0",
+            "ONLY_ACTIVE_ARCH": "NO",
+            "PRODUCT_NAME": "\"KitchenSinktablet\"",
+            "TARGETED_DEVICE_FAMILY": "\"1,2\""
+          },
+          "name": "Release"
+        },
+        "1D6058950D05DD3E006BFB54_comment": "Release",
+        "C01FCF4F08A954540054247B": {
+          "isa": "XCBuildConfiguration",
+          "baseConfigurationReference": "307D28A1123043350040C0FA",
+          "baseConfigurationReference_comment": "PhoneGapBuildSettings.xcconfig",
+          "buildSettings": {
+            "ARCHS": "\"$(ARCHS_STANDARD_32_BIT)\"",
+            "\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\"": "\"iPhone Distribution\"",
+            "GCC_C_LANGUAGE_STANDARD": "c99",
+            "GCC_VERSION": "com.apple.compilers.llvmgcc42",
+            "GCC_WARN_ABOUT_RETURN_TYPE": "YES",
+            "GCC_WARN_UNUSED_VARIABLE": "YES",
+            "IPHONEOS_DEPLOYMENT_TARGET": "3.0",
+            "OTHER_LDFLAGS": [
+              "\"-weak_framework\"",
+              "UIKit",
+              "\"-weak_framework\"",
+              "AVFoundation",
+              "\"-weak_framework\"",
+              "CoreMedia",
+              "\"-weak_library\"",
+              "/usr/lib/libSystem.B.dylib",
+              "\"-all_load\"",
+              "\"-Obj-C\""
+            ],
+            "PREBINDING": "NO",
+            "SDKROOT": "iphoneos",
+            "SKIP_INSTALL": "NO",
+            "USER_HEADER_SEARCH_PATHS": "\"\"$(PHONEGAPLIB)/Classes/JSON\" \"$(PHONEGAPLIB)/Classes\"\""
+          },
+          "name": "Debug"
+        },
+        "C01FCF4F08A954540054247B_comment": "Debug",
+        "C01FCF5008A954540054247B": {
+          "isa": "XCBuildConfiguration",
+          "baseConfigurationReference": "307D28A1123043350040C0FA",
+          "baseConfigurationReference_comment": "PhoneGapBuildSettings.xcconfig",
+          "buildSettings": {
+            "ARCHS": "\"$(ARCHS_STANDARD_32_BIT)\"",
+            "\"CODE_SIGN_IDENTITY[sdk=iphoneos*]\"": "\"iPhone Distribution\"",
+            "GCC_C_LANGUAGE_STANDARD": "c99",
+            "GCC_VERSION": "com.apple.compilers.llvmgcc42",
+            "GCC_WARN_ABOUT_RETURN_TYPE": "YES",
+            "GCC_WARN_UNUSED_VARIABLE": "YES",
+            "IPHONEOS_DEPLOYMENT_TARGET": "3.0",
+            "OTHER_LDFLAGS": [
+              "\"-weak_framework\"",
+              "UIKit",
+              "\"-weak_framework\"",
+              "AVFoundation",
+              "\"-weak_framework\"",
+              "CoreMedia",
+              "\"-weak_library\"",
+              "/usr/lib/libSystem.B.dylib",
+              "\"-all_load\"",
+              "\"-Obj-C\""
+            ],
+            "PREBINDING": "NO",
+            "SDKROOT": "iphoneos",
+            "SKIP_INSTALL": "NO",
+            "USER_HEADER_SEARCH_PATHS": "\"\"$(PHONEGAPLIB)/Classes/JSON\" \"$(PHONEGAPLIB)/Classes\"\""
+          },
+          "name": "Release"
+        },
+        "C01FCF5008A954540054247B_comment": "Release"
+      },
+      "XCConfigurationList": {
+        "1D6058960D05DD3E006BFB54": {
+          "isa": "XCConfigurationList",
+          "buildConfigurations": [
+            {
+              "value": "1D6058940D05DD3E006BFB54",
+              "comment": "Debug"
+            },
+            {
+              "value": "1D6058950D05DD3E006BFB54",
+              "comment": "Release"
+            }
+          ],
+          "defaultConfigurationIsVisible": 0,
+          "defaultConfigurationName": "Release"
+        },
+        "1D6058960D05DD3E006BFB54_comment": "Build configuration list for PBXNativeTarget \"KitchenSinktablet\"",
+        "C01FCF4E08A954540054247B": {
+          "isa": "XCConfigurationList",
+          "buildConfigurations": [
+            {
+              "value": "C01FCF4F08A954540054247B",
+              "comment": "Debug"
+            },
+            {
+              "value": "C01FCF5008A954540054247B",
+              "comment": "Release"
+            }
+          ],
+          "defaultConfigurationIsVisible": 0,
+          "defaultConfigurationName": "Release"
+        },
+        "C01FCF4E08A954540054247B_comment": "Build configuration list for PBXProject \"KitchenSinktablet\""
+      }
+    },
+    "rootObject": "29B97313FDCFA39411CA2CEA",
+    "rootObject_comment": "Project object"
+  },
+  "headComment": "!$*UTF8*$!"
+}

--- a/test/fixtures/multiple-data-model.xcdatamodeld/.xccurrentversion
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>2.xcdatamodel</string>
+</dict>
+</plist>

--- a/test/fixtures/multiple-data-model.xcdatamodeld/1.xcdatamodel/contents
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/1.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/fixtures/multiple-data-model.xcdatamodeld/2.xcdatamodel/contents
+++ b/test/fixtures/multiple-data-model.xcdatamodeld/2.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/fixtures/single-data-model.xcdatamodeld/SingleDataModel.xcdatamodel/contents
+++ b/test/fixtures/single-data-model.xcdatamodeld/SingleDataModel.xcdatamodel/contents
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="15B42" minimumToolsVersion="Xcode 7.0">
+    <elements/>
+</model>

--- a/test/group.js
+++ b/test/group.js
@@ -185,7 +185,7 @@ exports.removeSourceFileFromGroup = {
 }
 
 exports.addHeaderFileToGroup = {
-    'should create group + add source file' : function(test) {
+    'should create group + add header file' : function(test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
@@ -197,7 +197,7 @@ exports.addHeaderFileToGroup = {
 }
 
 exports.removeHeaderFileFromGroup = {
-    'should create group + add source file then remove source file' : function(test) {
+    'should create group + add source file then remove header file' : function(test) {
         var testKey = project.pbxCreateGroup('Test', 'Test');
         var file = project.addHeaderFile('Notifications.h', {}, testKey);
 
@@ -205,6 +205,36 @@ exports.removeHeaderFileFromGroup = {
         test.ok(foundInGroup);
 
         project.removeHeaderFile('Notifications.h', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(!foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.addResourceFileToGroup = {
+    'should add resource file (PNG) to the splash group' : function(test) {
+        
+        var testKey = project.findPBXGroupKey({path:'splash'});
+        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.removeResourceFileFromGroup = {
+    'should add resource file (PNG) then remove resource file from splash group' : function(test) {
+        var testKey = project.findPBXGroupKey({path:'splash'});
+        var file = project.addResourceFile('DefaultTest-667h.png', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        project.removeResourceFile('DefaultTest-667h.png', {}, testKey);
 
         var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
         test.ok(!foundInGroup);

--- a/test/group.js
+++ b/test/group.js
@@ -1,0 +1,320 @@
+var pbx = require('../lib/pbxProject'),
+    project,
+    projectHash;
+
+var findChildInGroup = function(obj, target) {
+    var found = false;
+
+    for (var i = 0, j = obj.children.length; i < j; i++) {
+        if (obj.children[i].value === target) {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+}
+
+var findFileByUUID = function(obj, target) {
+    var found = false;
+
+    for (var k = 0, l = obj.files.length; k < l; k++) {
+        if (obj.files[k].value === target) {
+            found = true;
+            break;
+        }
+    }
+
+    return found;
+}
+
+var findByFileRef = function(obj, target) {
+    var found = false;
+
+    for (var property in obj) {
+        if (!/comment/.test(property)) {
+            if (obj[property].fileRef === target) {
+                found = true;
+                break;
+            }
+        }
+    }
+    return found;
+}
+
+var findByName = function(obj, target) {
+    var found = false;
+    for (var property in obj) {
+        if (!/comment/.test(property)) {
+            var value = obj[property];
+            if (value.name === target) {
+                found = true;
+            }
+        }
+    }
+    return found;
+}
+
+exports.setUp = function(callback) {
+    project = new pbx('test/parser/projects/group.pbxproj');
+    projectHash = project.parseSync();
+    callback();
+}
+
+exports.getGroupByKey = {
+    'should return PBXGroup for Classes': function(test) {
+        var groupKey = project.findPBXGroupKey({name: 'Classes'});
+        var group = project.getPBXGroupByKey(groupKey);
+        test.ok(group.name === 'Classes');
+        test.done();
+    },
+    'should return PBXGroup for Plugins': function(test) {
+        var groupKey = project.findPBXGroupKey({name: 'Plugins'});
+        var group = project.getPBXGroupByKey(groupKey);
+        test.ok(group.name === 'Plugins');
+        test.done();
+    }
+}
+
+exports.createGroup = {
+    'should create a new Test Group': function(test) {
+        var found = false;
+        var groups = project.getPBXObject('PBXGroup');
+
+        var found = findByName(groups, 'Test');
+        test.ok(found === false);
+
+
+        var group = project.findPBXGroupKey({name:'Test'});
+        test.ok(group === undefined);
+
+        project.pbxCreateGroup('Test', 'Test');
+
+        groups = project.getPBXObject('PBXGroup');
+        found = findByName(groups, 'Test');
+        test.ok(found === true);
+
+        group = project.findPBXGroupKey({name:'Test'});
+        test.ok(typeof group === 'string');
+        test.done();
+    }
+}
+
+exports.findGroupKey = {
+    'should return a valid group key':function(test) {
+        var keyByName = project.findPBXGroupKey({ name: 'Classes'});
+        var keyByPath = project.findPBXGroupKey({ path: 'icons'});
+        var keyByPathName = project.findPBXGroupKey({ path: '"HelloCordova/Plugins"', name: 'Plugins'});
+        var nonExistingKey = project.findPBXGroupKey({ name: 'Foo'});
+
+        test.ok(keyByName === '080E96DDFE201D6D7F000001');
+        test.ok(keyByPath === '308D052D1370CCF300D202BF');
+        test.ok(keyByPathName === '307C750510C5A3420062BCA9');
+        test.ok(nonExistingKey === undefined);
+
+        test.done();
+    }
+}
+
+exports.addGroupToGroup = {
+    'should create a new test group then add group to Classes group': function(test) {
+        var testKey = project.pbxCreateGroup('Test', 'Test');
+        var classesKey = project.findPBXGroupKey({name: 'Classes'});
+        project.addToPbxGroup(testKey, classesKey);
+
+        var classesGroup = project.getPBXGroupByKey(classesKey);
+        var foundTestGroup = false;
+        for (var i = 0, j = classesGroup.children.length; i < j; i++) {
+            var child = classesGroup.children[i];
+            if (child.value === testKey && child.comment === 'Test') {
+                foundTestGroup = true;
+            }
+        }
+
+        test.ok(foundTestGroup);
+
+        test.done();
+    }
+}
+
+exports.addSourceFileToGroup = {
+    'should create group + add source file' : function(test) {
+        var testKey = project.pbxCreateGroup('Test', 'Test');
+        var file = project.addSourceFile('Notifications.m', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        test.ok(foundInBuildFileSection);
+
+        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        test.ok(foundInBuildPhase);
+
+        test.done();
+    }
+}
+
+exports.removeSourceFileFromGroup = {
+    'should create group + add source file then remove source file' : function(test) {
+        var testKey = project.pbxCreateGroup('Test', 'Test');
+        var file = project.addSourceFile('Notifications.m', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        test.ok(foundInBuildFileSection);
+
+        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        test.ok(foundInBuildPhase);
+
+        project.removeSourceFile('Notifications.m', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(!foundInGroup);
+
+        var foundInBuildFileSection = findByFileRef(project.pbxBuildFileSection(), file.fileRef);
+        test.ok(!foundInBuildFileSection);
+
+        var foundInBuildPhase = findFileByUUID(project.pbxSourcesBuildPhaseObj(), file.uuid);
+        test.ok(!foundInBuildPhase);
+
+        test.done();
+    }
+}
+
+exports.addHeaderFileToGroup = {
+    'should create group + add source file' : function(test) {
+        var testKey = project.pbxCreateGroup('Test', 'Test');
+        var file = project.addHeaderFile('Notifications.h', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.removeHeaderFileFromGroup = {
+    'should create group + add source file then remove source file' : function(test) {
+        var testKey = project.pbxCreateGroup('Test', 'Test');
+        var file = project.addHeaderFile('Notifications.h', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(foundInGroup);
+
+        project.removeHeaderFile('Notifications.h', {}, testKey);
+
+        var foundInGroup = findChildInGroup(project.getPBXGroupByKey(testKey),file.fileRef );
+        test.ok(!foundInGroup);
+
+        test.done();
+    }
+}
+
+exports.retrieveBuildPropertyForBuild = {
+    'should retrieve valid build property ':function(test) {
+        var releaseTargetedDeviceFamily = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Release');
+        var debugTargetedDeviceFamily = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Debug');
+        var nonExistingProperty = project.getBuildProperty('FOO', 'Debug');
+        var nonExistingBuild = project.getBuildProperty('TARGETED_DEVICE_FAMILY', 'Foo');
+
+        test.equal(releaseTargetedDeviceFamily, '"1,2"');
+        test.equal(debugTargetedDeviceFamily,'"1"');
+        test.equal(nonExistingProperty, undefined);
+        test.equal(nonExistingBuild, undefined);
+
+        test.done();
+    }
+}
+
+exports.retrieveBuildConfigByName = {
+    'should retrieve valid build config':function(test) {
+        var releaseBuildConfig = project.getBuildConfigByName('Release');
+        for (var property in releaseBuildConfig) {
+            var value = releaseBuildConfig[property];
+            test.ok(value.name === 'Release');
+        }
+
+        var debugBuildConfig = project.getBuildConfigByName('Debug');
+        for (var property in debugBuildConfig) {
+            var value = debugBuildConfig[property];
+            test.ok(value.name === 'Debug');
+        }
+
+        var nonExistingBuildConfig = project.getBuildConfigByName('Foo');
+        test.deepEqual(nonExistingBuildConfig, {});
+
+        test.done();
+    }
+}
+
+/* This proves the issue in 0.6.7
+exports.validatePropReplaceException = {
+    'should throw TypeError for updateBuildProperty VALID_ARCHS when none existed' : function(test) {
+        test.throws(
+            function() {
+                project.updateBuildProperty('VALID_ARCHS', '"armv7 armv7s');
+            },
+            TypeError,
+            "Object object has no method 'hasOwnProperty'"
+        );
+        test.done();
+    }
+}
+*/
+
+exports.validatePropReplaceFix = {
+    'should create build configuration for VALID_ARCHS when none existed' : function(test) {
+        project.updateBuildProperty('VALID_ARCHS', '"armv7 armv7s"', 'Debug');
+        test.done();
+    }
+}
+
+exports.validateHasFile = {
+    'should return true for has file MainViewController.m': function(test) {
+        var result = project.hasFile('MainViewController.m');
+        test.ok(result.path == "MainViewController.m");
+        test.done();
+    }
+}
+
+exports.testWritingPBXProject = {
+
+    'should successfully write to PBXProject TargetAttributes': function(test) {
+        var pbxProjectObj = project.getPBXObject('PBXProject');
+        var pbxProject;
+        for (var property in pbxProjectObj) {
+            if (!/comment/.test(property)) {
+                pbxProject = pbxProjectObj[property];
+            }
+        }
+
+        var target;
+        var projectTargets = pbxProject.targets;
+        for (var i = 0, j = pbxProject.targets.length; i < j; i++ ) {
+            target = pbxProject.targets[i].value;
+        }
+
+        pbxProject.attributes.TargetAttributes = {};
+        pbxProject.attributes.TargetAttributes[target] = {
+            DevelopmentTeam: 'N6X4RJZZ5D',
+            SystemCapabilities: {
+                "com.apple.BackgroundModes": {
+                    enabled : 0
+                },
+                "com.apple.DataProtection" : {
+                    enabled : 0
+                },
+                "com.apple.Keychain" : {
+                    enabled: 1
+                }
+            }
+        };
+
+        var output = project.writeSync();
+
+        test.done();
+    }
+}

--- a/test/parser/projects/group.pbxproj
+++ b/test/parser/projects/group.pbxproj
@@ -1,0 +1,575 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1D3623260D0F684500981E51 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* AppDelegate.m */; };
+		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
+		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
+		301BF552109A68D80062928A /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 301BF535109A57CC0062928A /* libCordova.a */; };
+		302D95F114D2391D003F00A1 /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 302D95EF14D2391D003F00A1 /* MainViewController.m */; };
+		302D95F214D2391D003F00A1 /* MainViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 302D95F014D2391D003F00A1 /* MainViewController.xib */; };
+		305D5FD1115AB8F900A74A75 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 305D5FD0115AB8F900A74A75 /* MobileCoreServices.framework */; };
+		3088BBBD154F3926009F9C59 /* Default-Landscape@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBB7154F3926009F9C59 /* Default-Landscape@2x~ipad.png */; };
+		3088BBBE154F3926009F9C59 /* Default-Landscape~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBB8154F3926009F9C59 /* Default-Landscape~ipad.png */; };
+		3088BBBF154F3926009F9C59 /* Default-Portrait@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBB9154F3926009F9C59 /* Default-Portrait@2x~ipad.png */; };
+		3088BBC0154F3926009F9C59 /* Default-Portrait~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBBA154F3926009F9C59 /* Default-Portrait~ipad.png */; };
+		3088BBC1154F3926009F9C59 /* Default@2x~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBBB154F3926009F9C59 /* Default@2x~iphone.png */; };
+		3088BBC2154F3926009F9C59 /* Default~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = 3088BBBC154F3926009F9C59 /* Default~iphone.png */; };
+		308D05371370CCF300D202BF /* icon-72.png in Resources */ = {isa = PBXBuildFile; fileRef = 308D052E1370CCF300D202BF /* icon-72.png */; };
+		308D05381370CCF300D202BF /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 308D052F1370CCF300D202BF /* icon.png */; };
+		308D05391370CCF300D202BF /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 308D05301370CCF300D202BF /* icon@2x.png */; };
+		30B4F30019D5E07200D9F7D8 /* Default-667h.png in Resources */ = {isa = PBXBuildFile; fileRef = 30B4F2FD19D5E07200D9F7D8 /* Default-667h.png */; };
+		30B4F30119D5E07200D9F7D8 /* Default-736h.png in Resources */ = {isa = PBXBuildFile; fileRef = 30B4F2FE19D5E07200D9F7D8 /* Default-736h.png */; };
+		30B4F30219D5E07200D9F7D8 /* Default-Landscape-736h.png in Resources */ = {isa = PBXBuildFile; fileRef = 30B4F2FF19D5E07200D9F7D8 /* Default-Landscape-736h.png */; };
+		30C1856619D5FC0A00212699 /* icon-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 30C1856519D5FC0A00212699 /* icon-60@3x.png */; };
+		30FC414916E50CA1004E6F35 /* icon-72@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 30FC414816E50CA1004E6F35 /* icon-72@2x.png */; };
+		5B1594DD16A7569C00FEF299 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B1594DC16A7569C00FEF299 /* AssetsLibrary.framework */; };
+		7E7966DE1810823500FA85AD /* icon-40.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D41810823500FA85AD /* icon-40.png */; };
+		7E7966DF1810823500FA85AD /* icon-40@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D51810823500FA85AD /* icon-40@2x.png */; };
+		7E7966E01810823500FA85AD /* icon-50.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D61810823500FA85AD /* icon-50.png */; };
+		7E7966E11810823500FA85AD /* icon-50@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D71810823500FA85AD /* icon-50@2x.png */; };
+		7E7966E21810823500FA85AD /* icon-60.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D81810823500FA85AD /* icon-60.png */; };
+		7E7966E31810823500FA85AD /* icon-60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966D91810823500FA85AD /* icon-60@2x.png */; };
+		7E7966E41810823500FA85AD /* icon-76.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966DA1810823500FA85AD /* icon-76.png */; };
+		7E7966E51810823500FA85AD /* icon-76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966DB1810823500FA85AD /* icon-76@2x.png */; };
+		7E7966E61810823500FA85AD /* icon-small.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966DC1810823500FA85AD /* icon-small.png */; };
+		7E7966E71810823500FA85AD /* icon-small@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E7966DD1810823500FA85AD /* icon-small@2x.png */; };
+		D4A0D8761607E02300AEF8BB /* Default-568h@2x~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = D4A0D8751607E02300AEF8BB /* Default-568h@2x~iphone.png */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		301BF534109A57CC0062928A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D2AAC07E0554694100DB518D;
+			remoteInfo = CordovaLib;
+		};
+		301BF550109A68C00062928A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D2AAC07D0554694100DB518D;
+			remoteInfo = CordovaLib;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		1D3623240D0F684500981E51 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		1D3623250D0F684500981E51 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		1D6058910D05DD3D006BFB54 /* HelloCordova.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "HelloCordova.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F766FDD13BBADB100FB74C0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
+		1F766FE013BBADB100FB74C0 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = Localizable.strings; sourceTree = "<group>"; };
+		288765FC0DF74451002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CordovaLib.xcodeproj; path = "CordovaLib/CordovaLib.xcodeproj"; sourceTree = "<group>"; };
+		301BF56E109A69640062928A /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; path = www; sourceTree = SOURCE_ROOT; };
+		302D95EE14D2391D003F00A1 /* MainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MainViewController.h; sourceTree = "<group>"; };
+		302D95EF14D2391D003F00A1 /* MainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MainViewController.m; sourceTree = "<group>"; };
+		302D95F014D2391D003F00A1 /* MainViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainViewController.xib; sourceTree = "<group>"; };
+		305D5FD0115AB8F900A74A75 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		3088BBB7154F3926009F9C59 /* Default-Landscape@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-Landscape@2x~ipad.png"; sourceTree = "<group>"; };
+		3088BBB8154F3926009F9C59 /* Default-Landscape~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-Landscape~ipad.png"; sourceTree = "<group>"; };
+		3088BBB9154F3926009F9C59 /* Default-Portrait@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-Portrait@2x~ipad.png"; sourceTree = "<group>"; };
+		3088BBBA154F3926009F9C59 /* Default-Portrait~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-Portrait~ipad.png"; sourceTree = "<group>"; };
+		3088BBBB154F3926009F9C59 /* Default@2x~iphone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x~iphone.png"; sourceTree = "<group>"; };
+		3088BBBC154F3926009F9C59 /* Default~iphone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default~iphone.png"; sourceTree = "<group>"; };
+		308D052E1370CCF300D202BF /* icon-72.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-72.png"; sourceTree = "<group>"; };
+		308D052F1370CCF300D202BF /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
+		308D05301370CCF300D202BF /* icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon@2x.png"; sourceTree = "<group>"; };
+		30B4F2FD19D5E07200D9F7D8 /* Default-667h.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-667h.png"; sourceTree = "<group>"; };
+		30B4F2FE19D5E07200D9F7D8 /* Default-736h.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-736h.png"; sourceTree = "<group>"; };
+		30B4F2FF19D5E07200D9F7D8 /* Default-Landscape-736h.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-Landscape-736h.png"; sourceTree = "<group>"; };
+		30C1856519D5FC0A00212699 /* icon-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-60@3x.png"; sourceTree = "<group>"; };
+		30FC414816E50CA1004E6F35 /* icon-72@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-72@2x.png"; sourceTree = "<group>"; };
+		32CA4F630368D1EE00C91783 /* HelloCordova-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "HelloCordova-Prefix.pch"; sourceTree = "<group>"; };
+		5B1594DC16A7569C00FEF299 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		7E7966D41810823500FA85AD /* icon-40.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-40.png"; sourceTree = "<group>"; };
+		7E7966D51810823500FA85AD /* icon-40@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-40@2x.png"; sourceTree = "<group>"; };
+		7E7966D61810823500FA85AD /* icon-50.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-50.png"; sourceTree = "<group>"; };
+		7E7966D71810823500FA85AD /* icon-50@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-50@2x.png"; sourceTree = "<group>"; };
+		7E7966D81810823500FA85AD /* icon-60.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-60.png"; sourceTree = "<group>"; };
+		7E7966D91810823500FA85AD /* icon-60@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-60@2x.png"; sourceTree = "<group>"; };
+		7E7966DA1810823500FA85AD /* icon-76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-76.png"; sourceTree = "<group>"; };
+		7E7966DB1810823500FA85AD /* icon-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-76@2x.png"; sourceTree = "<group>"; };
+		7E7966DC1810823500FA85AD /* icon-small.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-small.png"; sourceTree = "<group>"; };
+		7E7966DD1810823500FA85AD /* icon-small@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon-small@2x.png"; sourceTree = "<group>"; };
+		8D1107310486CEB800E47090 /* HelloCordova-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "HelloCordova-Info.plist"; path = "../HelloCordova-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
+		D4A0D8751607E02300AEF8BB /* Default-568h@2x~iphone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x~iphone.png"; sourceTree = "<group>"; };
+		EB87FDF21871DA7A0020F90C /* merges */ = {isa = PBXFileReference; lastKnownFileType = folder; name = merges; path = ../../merges; sourceTree = "<group>"; };
+		EB87FDF31871DA8E0020F90C /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../www; sourceTree = "<group>"; };
+		EB87FDF41871DAF40020F90C /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = ../../config.xml; sourceTree = "<group>"; };
+		F840E1F0165FE0F500CFE078 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = config.xml; path = "HelloCordova/config.xml"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1D60588F0D05DD3D006BFB54 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B1594DD16A7569C00FEF299 /* AssetsLibrary.framework in Frameworks */,
+				301BF552109A68D80062928A /* libCordova.a in Frameworks */,
+				288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */,
+				305D5FD1115AB8F900A74A75 /* MobileCoreServices.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		080E96DDFE201D6D7F000001 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				302D95EE14D2391D003F00A1 /* MainViewController.h */,
+				302D95EF14D2391D003F00A1 /* MainViewController.m */,
+				302D95F014D2391D003F00A1 /* MainViewController.xib */,
+				1D3623240D0F684500981E51 /* AppDelegate.h */,
+				1D3623250D0F684500981E51 /* AppDelegate.m */,
+			);
+			name = Classes;
+			path = "HelloCordova/Classes";
+			sourceTree = SOURCE_ROOT;
+		};
+		19C28FACFE9D520D11CA2CBB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1D6058910D05DD3D006BFB54 /* HelloCordova.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+			isa = PBXGroup;
+			children = (
+				EB87FDF41871DAF40020F90C /* config.xml */,
+				EB87FDF31871DA8E0020F90C /* www */,
+				EB87FDF21871DA7A0020F90C /* merges */,
+				EB87FDF11871DA420020F90C /* Staging */,
+				301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */,
+				080E96DDFE201D6D7F000001 /* Classes */,
+				307C750510C5A3420062BCA9 /* Plugins */,
+				29B97315FDCFA39411CA2CEA /* Other Sources */,
+				29B97317FDCFA39411CA2CEA /* Resources */,
+				29B97323FDCFA39411CA2CEA /* Frameworks */,
+				19C28FACFE9D520D11CA2CBB /* Products */,
+			);
+			name = CustomTemplate;
+			sourceTree = "<group>";
+		};
+		29B97315FDCFA39411CA2CEA /* Other Sources */ = {
+			isa = PBXGroup;
+			children = (
+				32CA4F630368D1EE00C91783 /* HelloCordova-Prefix.pch */,
+				29B97316FDCFA39411CA2CEA /* main.m */,
+			);
+			name = "Other Sources";
+			path = "HelloCordova";
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				308D052D1370CCF300D202BF /* icons */,
+				308D05311370CCF300D202BF /* splash */,
+				8D1107310486CEB800E47090 /* HelloCordova-Info.plist */,
+			);
+			name = Resources;
+			path = "HelloCordova/Resources";
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				5B1594DC16A7569C00FEF299 /* AssetsLibrary.framework */,
+				288765FC0DF74451002DB57D /* CoreGraphics.framework */,
+				305D5FD0115AB8F900A74A75 /* MobileCoreServices.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		301BF52E109A57CC0062928A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				301BF535109A57CC0062928A /* libCordova.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		307C750510C5A3420062BCA9 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Plugins;
+			path = "HelloCordova/Plugins";
+			sourceTree = SOURCE_ROOT;
+		};
+		308D052D1370CCF300D202BF /* icons */ = {
+			isa = PBXGroup;
+			children = (
+				30C1856519D5FC0A00212699 /* icon-60@3x.png */,
+				7E7966D41810823500FA85AD /* icon-40.png */,
+				7E7966D51810823500FA85AD /* icon-40@2x.png */,
+				7E7966D61810823500FA85AD /* icon-50.png */,
+				7E7966D71810823500FA85AD /* icon-50@2x.png */,
+				7E7966D81810823500FA85AD /* icon-60.png */,
+				7E7966D91810823500FA85AD /* icon-60@2x.png */,
+				7E7966DA1810823500FA85AD /* icon-76.png */,
+				7E7966DB1810823500FA85AD /* icon-76@2x.png */,
+				7E7966DC1810823500FA85AD /* icon-small.png */,
+				7E7966DD1810823500FA85AD /* icon-small@2x.png */,
+				30FC414816E50CA1004E6F35 /* icon-72@2x.png */,
+				308D052E1370CCF300D202BF /* icon-72.png */,
+				308D052F1370CCF300D202BF /* icon.png */,
+				308D05301370CCF300D202BF /* icon@2x.png */,
+			);
+			path = icons;
+			sourceTree = "<group>";
+		};
+		308D05311370CCF300D202BF /* splash */ = {
+			isa = PBXGroup;
+			children = (
+				30B4F2FD19D5E07200D9F7D8 /* Default-667h.png */,
+				30B4F2FE19D5E07200D9F7D8 /* Default-736h.png */,
+				30B4F2FF19D5E07200D9F7D8 /* Default-Landscape-736h.png */,
+				D4A0D8751607E02300AEF8BB /* Default-568h@2x~iphone.png */,
+				3088BBB7154F3926009F9C59 /* Default-Landscape@2x~ipad.png */,
+				3088BBB8154F3926009F9C59 /* Default-Landscape~ipad.png */,
+				3088BBB9154F3926009F9C59 /* Default-Portrait@2x~ipad.png */,
+				3088BBBA154F3926009F9C59 /* Default-Portrait~ipad.png */,
+				3088BBBB154F3926009F9C59 /* Default@2x~iphone.png */,
+				3088BBBC154F3926009F9C59 /* Default~iphone.png */,
+			);
+			path = splash;
+			sourceTree = "<group>";
+		};
+		EB87FDF11871DA420020F90C /* Staging */ = {
+			isa = PBXGroup;
+			children = (
+				F840E1F0165FE0F500CFE078 /* config.xml */,
+				301BF56E109A69640062928A /* www */,
+			);
+			name = Staging;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1D6058900D05DD3D006BFB54 /* HelloCordova */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "HelloCordova" */;
+			buildPhases = (
+				304B58A110DAC018002A0835 /* Copy www directory */,
+				1D60588D0D05DD3D006BFB54 /* Resources */,
+				1D60588E0D05DD3D006BFB54 /* Sources */,
+				1D60588F0D05DD3D006BFB54 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				301BF551109A68C00062928A /* PBXTargetDependency */,
+			);
+			name = "HelloCordova";
+			productName = "HelloCordova";
+			productReference = 1D6058910D05DD3D006BFB54 /* HelloCordova.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		29B97313FDCFA39411CA2CEA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0510;
+			};
+			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "__CLI__" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+				en,
+				es,
+				de,
+				se,
+			);
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 301BF52E109A57CC0062928A /* Products */;
+					ProjectRef = 301BF52D109A57CC0062928A /* CordovaLib.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				1D6058900D05DD3D006BFB54 /* HelloCordova */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		301BF535109A57CC0062928A /* libCordova.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libCordova.a;
+			remoteRef = 301BF534109A57CC0062928A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1D60588D0D05DD3D006BFB54 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7E7966E41810823500FA85AD /* icon-76.png in Resources */,
+				7E7966DF1810823500FA85AD /* icon-40@2x.png in Resources */,
+				308D05371370CCF300D202BF /* icon-72.png in Resources */,
+				30B4F30119D5E07200D9F7D8 /* Default-736h.png in Resources */,
+				308D05381370CCF300D202BF /* icon.png in Resources */,
+				308D05391370CCF300D202BF /* icon@2x.png in Resources */,
+				302D95F214D2391D003F00A1 /* MainViewController.xib in Resources */,
+				7E7966E01810823500FA85AD /* icon-50.png in Resources */,
+				7E7966E31810823500FA85AD /* icon-60@2x.png in Resources */,
+				7E7966E61810823500FA85AD /* icon-small.png in Resources */,
+				3088BBBD154F3926009F9C59 /* Default-Landscape@2x~ipad.png in Resources */,
+				3088BBBE154F3926009F9C59 /* Default-Landscape~ipad.png in Resources */,
+				3088BBBF154F3926009F9C59 /* Default-Portrait@2x~ipad.png in Resources */,
+				7E7966E71810823500FA85AD /* icon-small@2x.png in Resources */,
+				3088BBC0154F3926009F9C59 /* Default-Portrait~ipad.png in Resources */,
+				30B4F30019D5E07200D9F7D8 /* Default-667h.png in Resources */,
+				7E7966DE1810823500FA85AD /* icon-40.png in Resources */,
+				3088BBC1154F3926009F9C59 /* Default@2x~iphone.png in Resources */,
+				7E7966E21810823500FA85AD /* icon-60.png in Resources */,
+				3088BBC2154F3926009F9C59 /* Default~iphone.png in Resources */,
+				D4A0D8761607E02300AEF8BB /* Default-568h@2x~iphone.png in Resources */,
+				30B4F30219D5E07200D9F7D8 /* Default-Landscape-736h.png in Resources */,
+				30C1856619D5FC0A00212699 /* icon-60@3x.png in Resources */,
+				7E7966E11810823500FA85AD /* icon-50@2x.png in Resources */,
+				7E7966E51810823500FA85AD /* icon-76@2x.png in Resources */,
+				30FC414916E50CA1004E6F35 /* icon-72@2x.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		304B58A110DAC018002A0835 /* Copy www directory */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy www directory";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cordova/lib/copy-www-build-step.sh";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1D60588E0D05DD3D006BFB54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D60589B0D05DD56006BFB54 /* main.m in Sources */,
+				1D3623260D0F684500981E51 /* AppDelegate.m in Sources */,
+				302D95F114D2391D003F00A1 /* MainViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		301BF551109A68C00062928A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CordovaLib;
+			targetProxy = 301BF550109A68C00062928A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1D6058940D05DD3E006BFB54 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "HelloCordova/HelloCordova-Prefix.pch";
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				INFOPLIST_FILE = "HelloCordova/HelloCordova-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					CoreFoundation,
+					"-weak_framework",
+					UIKit,
+					"-weak_framework",
+					AVFoundation,
+					"-weak_framework",
+					CoreMedia,
+					"-weak-lSystem",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "HelloCordova";
+				TARGETED_DEVICE_FAMILY = "1";
+			};
+			name = Debug;
+		};
+		1D6058950D05DD3E006BFB54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "HelloCordova/HelloCordova-Prefix.pch";
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				INFOPLIST_FILE = "HelloCordova/HelloCordova-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					CoreFoundation,
+					"-weak_framework",
+					UIKit,
+					"-weak_framework",
+					AVFoundation,
+					"-weak_framework",
+					CoreMedia,
+					"-weak-lSystem",
+					"-ObjC",
+				);
+				PRODUCT_NAME = "HelloCordova";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C01FCF4F08A954540054247B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"\"$(TARGET_BUILD_DIR)/usr/local/lib/include\"",
+					"\"$(OBJROOT)/UninstalledProducts/include\"",
+					"\"$(BUILT_PRODUCTS_DIR)\"",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					CoreFoundation,
+					"-weak_framework",
+					UIKit,
+					"-weak_framework",
+					AVFoundation,
+					"-weak_framework",
+					CoreMedia,
+					"-weak-lSystem",
+					"-ObjC",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				USER_HEADER_SEARCH_PATHS = "";
+			};
+			name = Debug;
+		};
+		C01FCF5008A954540054247B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_C_LANGUAGE_STANDARD = c99;
+				GCC_THUMB_SUPPORT = NO;
+				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"\"$(TARGET_BUILD_DIR)/usr/local/lib/include\"",
+					"\"$(OBJROOT)/UninstalledProducts/include\"",
+					"\"$(BUILT_PRODUCTS_DIR)\"",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					CoreFoundation,
+					"-weak_framework",
+					UIKit,
+					"-weak_framework",
+					AVFoundation,
+					"-weak_framework",
+					CoreMedia,
+					"-weak-lSystem",
+					"-ObjC",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = NO;
+				USER_HEADER_SEARCH_PATHS = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "HelloCordova" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1D6058940D05DD3E006BFB54 /* Debug */,
+				1D6058950D05DD3E006BFB54 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "__CLI__" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C01FCF4F08A954540054247B /* Debug */,
+				C01FCF5008A954540054247B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 29B97313FDCFA39411CA2CEA /* Project object */;
+}

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -50,6 +50,13 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
+    'should detect that a .xcdatamodel path means wrapper.xcdatamodel': function (test) {
+        var sourceFile = new pbxFile('dataModel.xcdatamodel');
+
+        test.equal('wrapper.xcdatamodel', sourceFile.lastKnownFileType);
+        test.done();
+    },
+
     'should allow lastKnownFileType to be overridden': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
                 { lastKnownFileType: 'somestupidtype' });
@@ -71,6 +78,12 @@ exports['group'] = {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
         test.equal('Sources', sourceFile.group);
+        test.done();
+    },
+    'should be Sources for data model document files': function (test) {
+        var dataModelFile = new pbxFile('dataModel.xcdatamodeld');
+
+        test.equal('Sources', dataModelFile.group);
         test.done();
     },
     'should be Frameworks for frameworks': function (test) {

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -208,7 +208,7 @@ exports['settings'] = {
 
     'should be {ATTRIBUTES:["CodeSignOnCopy"]} if sign specified': function (test) {
         var sourceFile = new pbxFile('signable.framework',
-            { sign: true });
+            { embed: true, sign: true });
 
         test.deepEqual({ATTRIBUTES:["CodeSignOnCopy"]}, sourceFile.settings);
         test.done();
@@ -216,7 +216,7 @@ exports['settings'] = {
 
     'should be {ATTRIBUTES:["Weak","CodeSignOnCopy"]} if both weak linking and sign specified': function (test) {
         var sourceFile = new pbxFile('signableWeak.framework',
-            { weak: true, sign: true });
+            { embed: true, weak: true, sign: true });
 
         test.deepEqual({ATTRIBUTES:["Weak", "CodeSignOnCopy"]}, sourceFile.settings);
         test.done();

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -1,67 +1,67 @@
 var pbxFile = require('../lib/pbxFile');
 
-exports['lastType'] = {
+exports['lastKnownFileType'] = {
     'should detect that a .m path means sourcecode.c.objc': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m');
 
-        test.equal('sourcecode.c.objc', sourceFile.lastType);
+        test.equal('sourcecode.c.objc', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .h path means sourceFile.c.h': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.h');
 
-        test.equal('sourcecode.c.h', sourceFile.lastType);
+        test.equal('sourcecode.c.h', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .bundle path means "wrapper.plug-in"': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.bundle');
 
-        test.equal('"wrapper.plug-in"', sourceFile.lastType);
+        test.equal('wrapper.plug-in', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .xib path means file.xib': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.xib');
 
-        test.equal('file.xib', sourceFile.lastType);
+        test.equal('file.xib', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .dylib path means "compiled.mach-o.dylib"': function (test) {
         var sourceFile = new pbxFile('libsqlite3.dylib');
 
-        test.equal('"compiled.mach-o.dylib"', sourceFile.lastType);
+        test.equal('compiled.mach-o.dylib', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .framework path means wrapper.framework': function (test) {
         var sourceFile = new pbxFile('MessageUI.framework');
 
-        test.equal('wrapper.framework', sourceFile.lastType);
+        test.equal('wrapper.framework', sourceFile.lastKnownFileType);
         test.done();
     },
 
     'should detect that a .a path means archive.ar': function (test) {
         var sourceFile = new pbxFile('libGoogleAnalytics.a');
 
-        test.equal('archive.ar', sourceFile.lastType);
+        test.equal('archive.ar', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should allow lastType to be overridden': function (test) {
+    'should allow lastKnownFileType to be overridden': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.m',
-                { lastType: 'somestupidtype' });
+                { lastKnownFileType: 'somestupidtype' });
 
-        test.equal('somestupidtype', sourceFile.lastType);
+        test.equal('somestupidtype', sourceFile.lastKnownFileType);
         test.done();
     },
 
-    'should set lastType to unknown if undetectable': function (test) {
+    'should set lastKnownFileType to unknown if undetectable': function (test) {
         var sourceFile = new pbxFile('Plugins/ChildBrowser.guh');
 
-        test.equal('unknown', sourceFile.lastType);
+        test.equal('unknown', sourceFile.lastKnownFileType);
         test.done();
     }
 }

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -36,6 +36,13 @@ exports['lastKnownFileType'] = {
         test.done();
     },
 
+    'should detect that a .tbd path means sourcecode.text-based-dylib-definition': function (test) {
+        var sourceFile = new pbxFile('libsqlite3.tbd');
+
+        test.equal('sourcecode.text-based-dylib-definition', sourceFile.lastKnownFileType);
+        test.done();
+    },
+
     'should detect that a .framework path means wrapper.framework': function (test) {
         var sourceFile = new pbxFile('MessageUI.framework');
 
@@ -86,8 +93,20 @@ exports['group'] = {
         test.equal('Sources', dataModelFile.group);
         test.done();
     },
-    'should be Frameworks for frameworks': function (test) {
+    'should be Frameworks for dylibs': function (test) {
         var framework = new pbxFile('libsqlite3.dylib');
+
+        test.equal('Frameworks', framework.group);
+        test.done();
+    },
+    'should be Frameworks for tbds': function (test) {
+        var framework = new pbxFile('libsqlite3.tbd');
+
+        test.equal('Frameworks', framework.group);
+        test.done();
+    },
+    'should be Frameworks for frameworks': function (test) {
+        var framework = new pbxFile('MessageUI.framework');
 
         test.equal('Frameworks', framework.group);
         test.done();
@@ -120,6 +139,13 @@ exports['basename'] = {
 exports['sourceTree'] = {
     'should be SDKROOT for dylibs': function (test) {
         var sourceFile = new pbxFile('libsqlite3.dylib');
+
+        test.equal('SDKROOT', sourceFile.sourceTree);
+        test.done();
+    },
+
+    'should be SDKROOT for tbds': function (test) {
+        var sourceFile = new pbxFile('libsqlite3.tbd');
 
         test.equal('SDKROOT', sourceFile.sourceTree);
         test.done();
@@ -160,6 +186,13 @@ exports['path'] = {
         var sourceFile = new pbxFile('libsqlite3.dylib');
 
         test.equal('usr/lib/libsqlite3.dylib', sourceFile.path);
+        test.done();
+    },
+
+    'should be "usr/lib" for tbds (relative to SDKROOT)': function (test) {
+        var sourceFile = new pbxFile('libsqlite3.tbd');
+
+        test.equal('usr/lib/libsqlite3.tbd', sourceFile.path);
         test.done();
     },
 

--- a/test/pbxFile.js
+++ b/test/pbxFile.js
@@ -186,7 +186,7 @@ exports['settings'] = {
       test.equal(undefined, sourceFile.settings);
       test.done();
     },
-  
+
     'should be undefined if weak is false or non-boolean': function (test) {
         var sourceFile1 = new pbxFile('social.framework',
             { weak: false });
@@ -203,6 +203,22 @@ exports['settings'] = {
             { weak: true });
 
         test.deepEqual({ATTRIBUTES:["Weak"]}, sourceFile.settings);
+        test.done();
+    },
+
+    'should be {ATTRIBUTES:["CodeSignOnCopy"]} if sign specified': function (test) {
+        var sourceFile = new pbxFile('signable.framework',
+            { sign: true });
+
+        test.deepEqual({ATTRIBUTES:["CodeSignOnCopy"]}, sourceFile.settings);
+        test.done();
+    },
+
+    'should be {ATTRIBUTES:["Weak","CodeSignOnCopy"]} if both weak linking and sign specified': function (test) {
+        var sourceFile = new pbxFile('signableWeak.framework',
+            { weak: true, sign: true });
+
+        test.deepEqual({ATTRIBUTES:["Weak", "CodeSignOnCopy"]}, sourceFile.settings);
         test.done();
     },
 

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -177,6 +177,90 @@ exports['updateBuildProperty function'] = {
     }
 }
 
+exports['addBuildProperty function'] = {
+    setUp:function(callback) {
+        callback();
+    },
+    tearDown:function(callback) {
+        fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
+        callback();
+    },
+    'should add 4 build properties in the .pbxproj file': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.addBuildProperty('ENABLE_BITCODE', 'NO');
+            var newContents = myProj.writeSync();
+            test.equal(newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length, 4);
+            test.done();
+        });
+    },
+    'should add 2 build properties in the .pbxproj file for specific build': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'Release');
+            var newContents = myProj.writeSync();
+            test.equal(newContents.match(/ENABLE_BITCODE\s*=\s*NO/g).length, 2);
+            test.done();
+        });
+    },
+    'should not add build properties in the .pbxproj file for nonexist build': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.addBuildProperty('ENABLE_BITCODE', 'NO', 'nonexist');
+            var newContents = myProj.writeSync();
+            test.ok(!newContents.match(/ENABLE_BITCODE\s*=\s*NO/g));
+            test.done();
+        });
+    }
+}
+
+exports['removeBuildProperty function'] = {
+    setUp:function(callback) {
+        callback();
+    },
+    tearDown:function(callback) {
+        fs.writeFileSync(bcpbx, original_pbx, 'utf-8');
+        callback();
+    },
+    'should remove all build properties in the .pbxproj file': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET');
+            var newContents = myProj.writeSync();
+            test.ok(!newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/));
+            test.done();
+        });
+    },
+    'should remove specific build properties in the .pbxproj file': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', 'Debug');
+            var newContents = myProj.writeSync();
+            test.equal(newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length, 2);
+            test.done();
+        });
+    },
+    'should not remove any build properties in the .pbxproj file': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.removeBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', 'notexist');
+            var newContents = myProj.writeSync();
+            test.equal(newContents.match(/IPHONEOS_DEPLOYMENT_TARGET/g).length, 4);
+            test.done();
+        });
+    },
+    'should fine with remove inexist build properties in the .pbxproj file': function (test) {
+        var myProj = new pbx('test/parser/projects/build-config.pbxproj');
+        myProj.parse(function(err, hash) {
+            myProj.removeBuildProperty('ENABLE_BITCODE');
+            var newContents = myProj.writeSync();
+            test.ok(!newContents.match(/ENABLE_BITCODE/));
+            test.done();
+        });
+    }
+
+}
+
 exports['productName field'] = {
     'should return the product name': function (test) {
         var newProj = new pbx('.');

--- a/test/removeFramework.js
+++ b/test/removeFramework.js
@@ -1,4 +1,4 @@
-var fullProject = require('./fixtures/full-project')
+var fullProject = require('./fixtures/full-project'),
     fullProjectStr = JSON.stringify(fullProject),
     pbx = require('../lib/pbxProject'),
     pbxFile = require('../lib/pbxFile'),
@@ -47,22 +47,22 @@ exports.removeFramework = {
         var newFile = proj.addFramework('libsqlite3.dylib');
 
         test.equal(newFile.constructor, pbxFile);
-        
+
         var deletedFile = proj.removeFramework('libsqlite3.dylib');
 
         test.equal(deletedFile.constructor, pbxFile);
-        
+
         test.done()
     },
     'should set a fileRef on the pbxFile': function (test) {
         var newFile = proj.addFramework('libsqlite3.dylib');
 
         test.ok(newFile.fileRef);
-        
+
         var deletedFile = proj.removeFramework('libsqlite3.dylib');
 
         test.ok(deletedFile.fileRef);
-        
+
         test.done()
     },
     'should remove 2 fields from the PBXFileReference section': function (test) {
@@ -80,7 +80,7 @@ exports.removeFramework = {
         test.equal(66, frsLength);
         test.ok(!fileRefSection[deletedFile.fileRef]);
         test.ok(!fileRefSection[deletedFile.fileRef + '_comment']);
-        
+
         test.done();
     },
     'should remove 2 fields from the PBXBuildFile section': function (test) {
@@ -93,13 +93,13 @@ exports.removeFramework = {
         test.ok(buildFileSection[newFile.uuid + '_comment']);
 
         var deletedFile = proj.removeFramework('libsqlite3.dylib');
-        
+
         bfsLength = Object.keys(buildFileSection).length;
 
         test.equal(58, bfsLength);
         test.ok(!buildFileSection[deletedFile.uuid]);
         test.ok(!buildFileSection[deletedFile.uuid + '_comment']);
-        
+
         test.done();
     },
     'should remove from the Frameworks PBXGroup': function (test) {
@@ -108,12 +108,12 @@ exports.removeFramework = {
             frameworks = proj.pbxGroupByName('Frameworks');
 
         test.equal(frameworks.children.length, newLength);
-        
+
         var deletedFile = proj.removeFramework('libsqlite3.dylib'),
         newLength = newLength - 1;
 
         test.equal(frameworks.children.length, newLength);
-        
+
         test.done();
     },
     'should remove from the PBXFrameworksBuildPhase': function (test) {
@@ -121,34 +121,33 @@ exports.removeFramework = {
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
-        
+
         var deletedFile = proj.removeFramework('libsqlite3.dylib'),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
-        
+
         test.done();
     },
     'should remove custom frameworks': function (test) {
-        var newFile = proj.addFramework('/path/to/Custom.framework'),
+        var newFile = proj.addFramework('/path/to/Custom.framework', { customFramework: true }),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 16);
-        
-        var deletedFile = proj.removeFramework('/path/to/Custom.framework'),
+
+        var deletedFile = proj.removeFramework('/path/to/Custom.framework', { customFramework: true }),
             frameworks = proj.pbxFrameworksBuildPhaseObj();
 
         test.equal(frameworks.files.length, 15);
-        
+
         var frameworkPaths = frameworkSearchPaths(proj);
             expectedPath = '"/path/to"';
 
         for (i = 0; i < frameworkPaths.length; i++) {
             var current = frameworkPaths[i];
-            test.ok(current.indexOf('"$(inherited)"') == -1);
             test.ok(current.indexOf(expectedPath) == -1);
         }
-        
+
         test.done();
     }
 }

--- a/test/removeResourceFile.js
+++ b/test/removeResourceFile.js
@@ -140,7 +140,7 @@ exports.removeResourceFile = {
 
         test.equal(fileRefEntry.isa, 'PBXFileReference');
         test.equal(fileRefEntry.fileEncoding, undefined);
-        test.equal(fileRefEntry.lastKnownFileType, '"wrapper.plug-in"');
+        test.equal(fileRefEntry.lastKnownFileType, 'wrapper.plug-in');
         test.equal(fileRefEntry.name, '"assets.bundle"');
         test.equal(fileRefEntry.path, '"Resources/assets.bundle"');
         test.equal(fileRefEntry.sourceTree, '"<group>"');


### PR DESCRIPTION
The name of the method `pbxNativeTarget` is changed to `pbxNativeTargetSection`. This is breaking the builds for Cordova >= 5.0.0 when executing plugin hooks because we use directly node-xcode to parse the project and we use the version which has `pbxNativeTargetSection` method. The builds for Cordova < 5.0.0 are ok because we use plugman to execute plugin hooks and plugman uses older version of node-xcode which has `pbxNativeTarget`. For backwards compatibility we need to add `pbxNativeTarget` method again.
